### PR TITLE
#8 merge dev to master

### DIFF
--- a/bindings/dragonruby/examples/hello_ice_batt.rb
+++ b/bindings/dragonruby/examples/hello_ice_batt.rb
@@ -1,0 +1,35 @@
+$gtk.ffi_misc.gtk_dlopen("ice_batt")
+include FFI::CExt
+
+def tick args
+  # Struct that contains information about the battery
+  batt ||= ICE_BATT_INFO_PTR.new
+
+  # Fetch battery information and store the information in the struct
+  err = ice_batt_get_info(batt)
+  
+  # If the function failed to fetch battery information, Trace error then terminate the program
+  if (err != 0)
+    puts("ERROR: failed to fetch battery information!")
+    return -1
+  end
+  
+  # Print the informations
+  args.outputs.primitives << {
+    x: 5,
+    y: 5.from_top,
+    text: "Device has battery: #{((batt.value.exists == 0) ? "YES" : "NO")}"
+  }.to_label
+  
+  args.outputs.primitives << {
+    x: 5,
+    y: 30.from_top,
+    text: "Is battery charging: #{((batt.value.charging == 0) ? "YES" : "NO")}"
+  }.to_label
+  
+  args.outputs.primitives << {
+    x: 5,
+    y: 55.from_top,
+    text: "Battery Level: #{batt.value.level}"
+  }.to_label
+end

--- a/bindings/dragonruby/examples/hello_ice_clip.rb
+++ b/bindings/dragonruby/examples/hello_ice_clip.rb
@@ -1,0 +1,44 @@
+$gtk.ffi_misc.gtk_dlopen("ice_clip")
+include FFI::CExt
+
+$gtk.show_console
+
+def boot args
+  # To store result of called functions
+  res = nil
+  
+  # String to copy to clipboard later...
+  str ||= "SPEED!"
+  
+  # Retrieve the clipboard text
+  text ||= ice_clip_get()
+  
+  # If the function failed to retrieve Clipboard text or Clipboard has no text then trace log a note, Else print the retrieved text... */
+  if (text.str == nil)
+    puts("LOG: failed to retrieve Clipboard text, Maybe the Clipboard does not contain text?")
+  else
+    puts("Text from the Clipboard: #{text.str}")
+  end
+  
+  # Clear the Clipboard
+  res = ice_clip_clear()
+  
+  # If the function failed to clear the Clipboard, Trace error then terminate the program
+  if (res == -1)
+    puts("ERROR: failed to clear the Clipboard!")
+    return -1
+  end
+  
+  # Copy text to Clipboard
+  res = ice_clip_set(str)
+  
+  # If the function failed to copy text to the Clipboard, Trace error then terminate the program
+  if (res == -1)
+    puts("ERROR: Failed to copy text to Clipboard!")
+    return
+  end
+    
+  puts("Text copied to the Clipboard: #{str}")
+  
+  return 0
+end

--- a/bindings/dragonruby/examples/hello_ice_cpu.rb
+++ b/bindings/dragonruby/examples/hello_ice_cpu.rb
@@ -1,0 +1,23 @@
+$gtk.ffi_misc.gtk_dlopen("ice_cpu")
+include FFI::CExt
+
+$gtk.show_console
+
+def boot args
+  # Struct that contains CPU information
+  cpu ||= ICE_CPU_INFO_PTR.new
+
+  # Get CPU information
+  res ||= ice_cpu_get_info(cpu)
+  
+  # If the function failed to retrieve CPU information, Trace error then terminate the program
+  if (res == -1)
+    puts("ERROR: failed to retrieve CPU information!")
+    return -1
+  end
+  
+  # Print the informations
+  puts("CPU Name: #{cpu.value.name.str}\nCPU Cores: #{cpu.value.cores}")
+
+  return 0
+end

--- a/bindings/dragonruby/examples/hello_ice_ram.rb
+++ b/bindings/dragonruby/examples/hello_ice_ram.rb
@@ -1,0 +1,35 @@
+$gtk.ffi_misc.gtk_dlopen("ice_ram")
+include FFI::CExt
+
+def tick args
+  # Struct that contains RAM information
+  ram ||= ICE_RAM_INFO_PTR.new
+  
+  # Fetch RAM info
+  res = ice_ram_get_info(ram)
+  
+  # If function failed to fetch RAM info, Trace error then terminate the program
+  if (res == -1)
+    puts("ERROR: failed to get RAM info!")
+    return -1
+  end
+  
+  # Print RAM info (free, used, total) in bytes
+  args.outputs.primitives << {
+    x: 5,
+    y: 5.from_top,
+    text: "Free RAM: #{ram.value.free} bytes"
+  }.to_label
+  
+  args.outputs.primitives << {
+    x: 5,
+    y: 30.from_top,
+    text: "Used RAM: #{ram.value.used} bytes"
+  }.to_label
+  
+  args.outputs.primitives << {
+    x: 5,
+    y: 55.from_top,
+    text: "Total RAM: #{ram.value.total} bytes"
+  }.to_label
+end

--- a/bindings/dragonruby/examples/hello_ice_str.rb
+++ b/bindings/dragonruby/examples/hello_ice_str.rb
@@ -1,0 +1,21 @@
+$gtk.ffi_misc.gtk_dlopen("ice_str")
+include FFI::CExt
+
+$gtk.show_console
+
+def boot args
+  # Create a string repeated for multiple times
+  haha ||= ice_str_dup("HA", 8) # HAHAHAHAHAHAHAHA
+  
+  # If the function failed to allocate string, Trace error then terminate the program
+  if (haha == 0)
+    puts("ERROR: failed to allocate string!")
+    return -1
+  end
+  
+  # Print the string, Once we done we deallocate/free the string
+  puts(haha.str)
+  ice_str_free(haha)
+
+  return 0
+end

--- a/bindings/dragonruby/examples/hello_ice_time.rb
+++ b/bindings/dragonruby/examples/hello_ice_time.rb
@@ -1,0 +1,25 @@
+$gtk.ffi_misc.gtk_dlopen("ice_time")
+include FFI::CExt
+
+def tick args
+  # Struct that contains Time information
+  current_time ||= ICE_TIME_INFO_PTR.new
+  
+  # Fetch time information and store it in the struct
+  res ||= ice_time_get_info(current_time)
+  
+  # If the function failed to fetch time information, Trace error then terminate the program!
+  if (res != 0)
+    puts("ERROR: failed to get time info!")
+    return -1
+  end
+  
+  # Print current time!
+  args.outputs.primitives << {
+    x: 5,
+    y: 5.from_top,
+    text: "Current Time: #{current_time.value.str.str}"
+  }.to_label
+  
+  return 0
+end

--- a/bindings/dragonruby/ice_batt_drb.c
+++ b/bindings/dragonruby/ice_batt_drb.c
@@ -67,7 +67,7 @@ static ice_batt_info *drb_ffi__ZTSP13ice_batt_info_FromRuby(mrb_state *state, mr
         return 0;
     struct RClass *FFI = mrb_module_get_f(state, "FFI");
     struct RClass *module = mrb_module_get_under_f(state, FFI, "CExt");
-    struct RClass *klass = mrb_class_get_under_f(state, module, "Ice_batt_infoPointer");
+    struct RClass *klass = mrb_class_get_under_f(state, module, "ICE_BATT_INFO_PTR");
     drb_typecheck_aggregate_f(state, self, klass, &ForeignObjectType_ZTSP13ice_batt_info);
     return ((struct drb_foreign_object_ZTSP13ice_batt_info *)DATA_PTR(self))->value;
 }
@@ -77,7 +77,7 @@ static mrb_value drb_ffi__ZTSP13ice_batt_info_ToRuby(mrb_state *state, ice_batt_
     ptr->kind = drb_foreign_object_kind_pointer;
     struct RClass *FFI = mrb_module_get_f(state, "FFI");
     struct RClass *module = mrb_module_get_under_f(state, FFI, "CExt");
-    struct RClass *klass = mrb_class_get_under_f(state, module, "Ice_batt_infoPointer");
+    struct RClass *klass = mrb_class_get_under_f(state, module, "ICE_BATT_INFO_PTR");
     struct RData *rdata = mrb_data_object_alloc_f(state, klass, ptr, &ForeignObjectType_ZTSP13ice_batt_info);
     return mrb_obj_value(rdata);
 }
@@ -85,11 +85,11 @@ struct drb_foreign_object_ZTS13ice_batt_info {
     drb_foreign_object_kind kind;
     ice_batt_info value;
 };
-static mrb_data_type ForeignObjectType_ZTS13ice_batt_info = {"ice_batt_info", drb_free_foreign_object_indirect};
+static mrb_data_type ForeignObjectType_ZTS13ice_batt_info = {"ICE_BATT_INFO", drb_free_foreign_object_indirect};
 static ice_batt_info drb_ffi__ZTS13ice_batt_info_FromRuby(mrb_state *state, mrb_value self) {
     struct RClass *FFI = mrb_module_get_f(state, "FFI");
     struct RClass *module = mrb_module_get_under_f(state, FFI, "CExt");
-    struct RClass *klass = mrb_class_get_under_f(state, module, "Ice_batt_info");
+    struct RClass *klass = mrb_class_get_under_f(state, module, "ICE_BATT_INFO");
     drb_typecheck_aggregate_f(state, self, klass, &ForeignObjectType_ZTS13ice_batt_info);
     return ((struct drb_foreign_object_ZTS13ice_batt_info *)DATA_PTR(self))->value;
 }
@@ -99,7 +99,7 @@ static mrb_value drb_ffi__ZTS13ice_batt_info_ToRuby(mrb_state *state, ice_batt_i
     ptr->kind = drb_foreign_object_kind_struct;
     struct RClass *FFI = mrb_module_get_f(state, "FFI");
     struct RClass *module = mrb_module_get_under_f(state, FFI, "CExt");
-    struct RClass *klass = mrb_class_get_under_f(state, module, "Ice_batt_info");
+    struct RClass *klass = mrb_class_get_under_f(state, module, "ICE_BATT_INFO");
     struct RData *rdata = mrb_data_object_alloc_f(state, klass, ptr, &ForeignObjectType_ZTS13ice_batt_info);
     return mrb_obj_value(rdata);
 }
@@ -124,7 +124,7 @@ static mrb_value drb_ffi__ZTSP13ice_batt_info_New(mrb_state *mrb, mrb_value self
     ptr->should_free = 1;
     struct RClass *FFI = mrb_module_get_f(mrb, "FFI");
     struct RClass *module = mrb_module_get_under_f(mrb, FFI, "CExt");
-    struct RClass *klass = mrb_class_get_under_f(mrb, module, "Ice_batt_infoPointer");
+    struct RClass *klass = mrb_class_get_under_f(mrb, module, "ICE_BATT_INFO_PTR");
     struct RData *rdata = mrb_data_object_alloc_f(mrb, klass, ptr, &ForeignObjectType_ZTSP13ice_batt_info);
     return mrb_obj_value(rdata);
 }
@@ -157,7 +157,7 @@ static mrb_value drb_ffi__ZTS13ice_batt_info_New(mrb_state *state, mrb_value sel
     struct drb_foreign_object_ZTS13ice_batt_info *ptr = calloc(1, sizeof(struct drb_foreign_object_ZTS13ice_batt_info *));
     struct RClass *FFI = mrb_module_get_f(state, "FFI");
     struct RClass *module = mrb_module_get_under_f(state, FFI, "CExt");
-    struct RClass *klass = mrb_class_get_under_f(state, module, "Ice_batt_info");
+    struct RClass *klass = mrb_class_get_under_f(state, module, "ICE_BATT_INFO");
     struct RData *rdata = mrb_data_object_alloc_f(state, klass, ptr, &ForeignObjectType_ZTS13ice_batt_info);
     return mrb_obj_value(rdata);
 }
@@ -215,20 +215,20 @@ void drb_register_c_extensions(void *(*lookup)(const char *), mrb_state *state, 
     struct RClass *module = mrb_define_module_under_f(state, FFI, "CExt");
     struct RClass *object_class = state->object_class;
     mrb_define_module_function_f(state, module, "ice_batt_get_info", drb_ffi_ice_batt_get_info_Binding, MRB_ARGS_REQ(1));
-    struct RClass *Ice_batt_infoPointerClass = mrb_define_class_under_f(state, module, "Ice_batt_infoPointer", object_class);
-    mrb_define_class_method_f(state, Ice_batt_infoPointerClass, "new", drb_ffi__ZTSP13ice_batt_info_New, MRB_ARGS_REQ(0));
-    mrb_define_method_f(state, Ice_batt_infoPointerClass, "value", drb_ffi__ZTSP13ice_batt_info_GetValue, MRB_ARGS_REQ(0));
-    mrb_define_method_f(state, Ice_batt_infoPointerClass, "[]", drb_ffi__ZTSP13ice_batt_info_GetAt, MRB_ARGS_REQ(1));
-    mrb_define_method_f(state, Ice_batt_infoPointerClass, "[]=", drb_ffi__ZTSP13ice_batt_info_SetAt, MRB_ARGS_REQ(2));
-    mrb_define_method_f(state, Ice_batt_infoPointerClass, "nil?", drb_ffi__ZTSP13ice_batt_info_IsNil, MRB_ARGS_REQ(0));
-    struct RClass *Ice_batt_infoClass = mrb_define_class_under_f(state, module, "Ice_batt_info", object_class);
-    mrb_define_class_method_f(state, Ice_batt_infoClass, "new", drb_ffi__ZTS13ice_batt_info_New, MRB_ARGS_REQ(0));
-    mrb_define_method_f(state, Ice_batt_infoClass, "exists", drb_ffi__ZTS13ice_batt_info_exists_Get, MRB_ARGS_REQ(0));
-    mrb_define_method_f(state, Ice_batt_infoClass, "exists=", drb_ffi__ZTS13ice_batt_info_exists_Set, MRB_ARGS_REQ(1));
-    mrb_define_method_f(state, Ice_batt_infoClass, "charging", drb_ffi__ZTS13ice_batt_info_charging_Get, MRB_ARGS_REQ(0));
-    mrb_define_method_f(state, Ice_batt_infoClass, "charging=", drb_ffi__ZTS13ice_batt_info_charging_Set, MRB_ARGS_REQ(1));
-    mrb_define_method_f(state, Ice_batt_infoClass, "level", drb_ffi__ZTS13ice_batt_info_level_Get, MRB_ARGS_REQ(0));
-    mrb_define_method_f(state, Ice_batt_infoClass, "level=", drb_ffi__ZTS13ice_batt_info_level_Set, MRB_ARGS_REQ(1));
+    struct RClass *ice_batt_info_ptr_class = mrb_define_class_under_f(state, module, "ICE_BATT_INFO_PTR", object_class);
+    mrb_define_class_method_f(state, ice_batt_info_ptr_class, "new", drb_ffi__ZTSP13ice_batt_info_New, MRB_ARGS_REQ(0));
+    mrb_define_method_f(state, ice_batt_info_ptr_class, "value", drb_ffi__ZTSP13ice_batt_info_GetValue, MRB_ARGS_REQ(0));
+    mrb_define_method_f(state, ice_batt_info_ptr_class, "[]", drb_ffi__ZTSP13ice_batt_info_GetAt, MRB_ARGS_REQ(1));
+    mrb_define_method_f(state, ice_batt_info_ptr_class, "[]=", drb_ffi__ZTSP13ice_batt_info_SetAt, MRB_ARGS_REQ(2));
+    mrb_define_method_f(state, ice_batt_info_ptr_class, "nil?", drb_ffi__ZTSP13ice_batt_info_IsNil, MRB_ARGS_REQ(0));
+    struct RClass *ice_batt_info_class = mrb_define_class_under_f(state, module, "ICE_BATT_INFO", object_class);
+    mrb_define_class_method_f(state, ice_batt_info_class, "new", drb_ffi__ZTS13ice_batt_info_New, MRB_ARGS_REQ(0));
+    mrb_define_method_f(state, ice_batt_info_class, "exists", drb_ffi__ZTS13ice_batt_info_exists_Get, MRB_ARGS_REQ(0));
+    mrb_define_method_f(state, ice_batt_info_class, "exists=", drb_ffi__ZTS13ice_batt_info_exists_Set, MRB_ARGS_REQ(1));
+    mrb_define_method_f(state, ice_batt_info_class, "charging", drb_ffi__ZTS13ice_batt_info_charging_Get, MRB_ARGS_REQ(0));
+    mrb_define_method_f(state, ice_batt_info_class, "charging=", drb_ffi__ZTS13ice_batt_info_charging_Set, MRB_ARGS_REQ(1));
+    mrb_define_method_f(state, ice_batt_info_class, "level", drb_ffi__ZTS13ice_batt_info_level_Get, MRB_ARGS_REQ(0));
+    mrb_define_method_f(state, ice_batt_info_class, "level=", drb_ffi__ZTS13ice_batt_info_level_Set, MRB_ARGS_REQ(1));
 }
 static int drb_ffi_init_indirect_functions(void *(*lookup)(const char *fnname)) {
   drb_symbol_lookup = lookup;

--- a/bindings/dragonruby/ice_cpu_drb.c
+++ b/bindings/dragonruby/ice_cpu_drb.c
@@ -67,7 +67,7 @@ static ice_cpu_info *drb_ffi__ZTSP12ice_cpu_info_FromRuby(mrb_state *state, mrb_
         return 0;
     struct RClass *FFI = mrb_module_get_f(state, "FFI");
     struct RClass *module = mrb_module_get_under_f(state, FFI, "CExt");
-    struct RClass *klass = mrb_class_get_under_f(state, module, "Ice_cpu_infoPointer");
+    struct RClass *klass = mrb_class_get_under_f(state, module, "ICE_CPU_INFO_PTR");
     drb_typecheck_aggregate_f(state, self, klass, &ForeignObjectType_ZTSP12ice_cpu_info);
     return ((struct drb_foreign_object_ZTSP12ice_cpu_info *)DATA_PTR(self))->value;
 }
@@ -77,7 +77,7 @@ static mrb_value drb_ffi__ZTSP12ice_cpu_info_ToRuby(mrb_state *state, ice_cpu_in
     ptr->kind = drb_foreign_object_kind_pointer;
     struct RClass *FFI = mrb_module_get_f(state, "FFI");
     struct RClass *module = mrb_module_get_under_f(state, FFI, "CExt");
-    struct RClass *klass = mrb_class_get_under_f(state, module, "Ice_cpu_infoPointer");
+    struct RClass *klass = mrb_class_get_under_f(state, module, "ICE_CPU_INFO_PTR");
     struct RData *rdata = mrb_data_object_alloc_f(state, klass, ptr, &ForeignObjectType_ZTSP12ice_cpu_info);
     return mrb_obj_value(rdata);
 }
@@ -85,11 +85,11 @@ struct drb_foreign_object_ZTS12ice_cpu_info {
     drb_foreign_object_kind kind;
     ice_cpu_info value;
 };
-static mrb_data_type ForeignObjectType_ZTS12ice_cpu_info = {"ice_cpu_info", drb_free_foreign_object_indirect};
+static mrb_data_type ForeignObjectType_ZTS12ice_cpu_info = {"ICE_CPU_INFO", drb_free_foreign_object_indirect};
 static ice_cpu_info drb_ffi__ZTS12ice_cpu_info_FromRuby(mrb_state *state, mrb_value self) {
     struct RClass *FFI = mrb_module_get_f(state, "FFI");
     struct RClass *module = mrb_module_get_under_f(state, FFI, "CExt");
-    struct RClass *klass = mrb_class_get_under_f(state, module, "Ice_cpu_info");
+    struct RClass *klass = mrb_class_get_under_f(state, module, "ICE_CPU_INFO");
     drb_typecheck_aggregate_f(state, self, klass, &ForeignObjectType_ZTS12ice_cpu_info);
     return ((struct drb_foreign_object_ZTS12ice_cpu_info *)DATA_PTR(self))->value;
 }
@@ -99,7 +99,7 @@ static mrb_value drb_ffi__ZTS12ice_cpu_info_ToRuby(mrb_state *state, ice_cpu_inf
     ptr->kind = drb_foreign_object_kind_struct;
     struct RClass *FFI = mrb_module_get_f(state, "FFI");
     struct RClass *module = mrb_module_get_under_f(state, FFI, "CExt");
-    struct RClass *klass = mrb_class_get_under_f(state, module, "Ice_cpu_info");
+    struct RClass *klass = mrb_class_get_under_f(state, module, "ICE_CPU_INFO");
     struct RData *rdata = mrb_data_object_alloc_f(state, klass, ptr, &ForeignObjectType_ZTS12ice_cpu_info);
     return mrb_obj_value(rdata);
 }
@@ -151,7 +151,7 @@ static mrb_value drb_ffi__ZTSP12ice_cpu_info_New(mrb_state *mrb, mrb_value self)
     ptr->should_free = 1;
     struct RClass *FFI = mrb_module_get_f(mrb, "FFI");
     struct RClass *module = mrb_module_get_under_f(mrb, FFI, "CExt");
-    struct RClass *klass = mrb_class_get_under_f(mrb, module, "Ice_cpu_infoPointer");
+    struct RClass *klass = mrb_class_get_under_f(mrb, module, "ICE_CPU_INFO_PTR");
     struct RData *rdata = mrb_data_object_alloc_f(mrb, klass, ptr, &ForeignObjectType_ZTSP12ice_cpu_info);
     return mrb_obj_value(rdata);
 }
@@ -223,7 +223,7 @@ static mrb_value drb_ffi__ZTS12ice_cpu_info_New(mrb_state *state, mrb_value self
     struct drb_foreign_object_ZTS12ice_cpu_info *ptr = calloc(1, sizeof(struct drb_foreign_object_ZTS12ice_cpu_info *));
     struct RClass *FFI = mrb_module_get_f(state, "FFI");
     struct RClass *module = mrb_module_get_under_f(state, FFI, "CExt");
-    struct RClass *klass = mrb_class_get_under_f(state, module, "Ice_cpu_info");
+    struct RClass *klass = mrb_class_get_under_f(state, module, "ICE_CPU_INFO");
     struct RData *rdata = mrb_data_object_alloc_f(state, klass, ptr, &ForeignObjectType_ZTS12ice_cpu_info);
     return mrb_obj_value(rdata);
 }
@@ -269,12 +269,12 @@ void drb_register_c_extensions(void *(*lookup)(const char *), mrb_state *state, 
     struct RClass *module = mrb_define_module_under_f(state, FFI, "CExt");
     struct RClass *object_class = state->object_class;
     mrb_define_module_function_f(state, module, "ice_cpu_get_info", drb_ffi_ice_cpu_get_info_Binding, MRB_ARGS_REQ(1));
-    struct RClass *Ice_cpu_infoPointerClass = mrb_define_class_under_f(state, module, "Ice_cpu_infoPointer", object_class);
-    mrb_define_class_method_f(state, Ice_cpu_infoPointerClass, "new", drb_ffi__ZTSP12ice_cpu_info_New, MRB_ARGS_REQ(0));
-    mrb_define_method_f(state, Ice_cpu_infoPointerClass, "value", drb_ffi__ZTSP12ice_cpu_info_GetValue, MRB_ARGS_REQ(0));
-    mrb_define_method_f(state, Ice_cpu_infoPointerClass, "[]", drb_ffi__ZTSP12ice_cpu_info_GetAt, MRB_ARGS_REQ(1));
-    mrb_define_method_f(state, Ice_cpu_infoPointerClass, "[]=", drb_ffi__ZTSP12ice_cpu_info_SetAt, MRB_ARGS_REQ(2));
-    mrb_define_method_f(state, Ice_cpu_infoPointerClass, "nil?", drb_ffi__ZTSP12ice_cpu_info_IsNil, MRB_ARGS_REQ(0));
+    struct RClass *ice_cpu_info_ptr_class = mrb_define_class_under_f(state, module, "ICE_CPU_INFO_PTR", object_class);
+    mrb_define_class_method_f(state, ice_cpu_info_ptr_class, "new", drb_ffi__ZTSP12ice_cpu_info_New, MRB_ARGS_REQ(0));
+    mrb_define_method_f(state, ice_cpu_info_ptr_class, "value", drb_ffi__ZTSP12ice_cpu_info_GetValue, MRB_ARGS_REQ(0));
+    mrb_define_method_f(state, ice_cpu_info_ptr_class, "[]", drb_ffi__ZTSP12ice_cpu_info_GetAt, MRB_ARGS_REQ(1));
+    mrb_define_method_f(state, ice_cpu_info_ptr_class, "[]=", drb_ffi__ZTSP12ice_cpu_info_SetAt, MRB_ARGS_REQ(2));
+    mrb_define_method_f(state, ice_cpu_info_ptr_class, "nil?", drb_ffi__ZTSP12ice_cpu_info_IsNil, MRB_ARGS_REQ(0));
     struct RClass *CharPointerClass = mrb_define_class_under_f(state, module, "CharPointer", object_class);
     mrb_define_class_method_f(state, CharPointerClass, "new", drb_ffi__ZTSPc_New, MRB_ARGS_REQ(0));
     mrb_define_method_f(state, CharPointerClass, "value", drb_ffi__ZTSPc_GetValue, MRB_ARGS_REQ(0));
@@ -282,12 +282,12 @@ void drb_register_c_extensions(void *(*lookup)(const char *), mrb_state *state, 
     mrb_define_method_f(state, CharPointerClass, "[]=", drb_ffi__ZTSPc_SetAt, MRB_ARGS_REQ(2));
     mrb_define_method_f(state, CharPointerClass, "nil?", drb_ffi__ZTSPc_IsNil, MRB_ARGS_REQ(0));
     mrb_define_method_f(state, CharPointerClass, "str", drb_ffi__ZTSPc_GetString, MRB_ARGS_REQ(0));
-    struct RClass *Ice_cpu_infoClass = mrb_define_class_under_f(state, module, "Ice_cpu_info", object_class);
-    mrb_define_class_method_f(state, Ice_cpu_infoClass, "new", drb_ffi__ZTS12ice_cpu_info_New, MRB_ARGS_REQ(0));
-    mrb_define_method_f(state, Ice_cpu_infoClass, "name", drb_ffi__ZTS12ice_cpu_info_name_Get, MRB_ARGS_REQ(0));
-    mrb_define_method_f(state, Ice_cpu_infoClass, "name=", drb_ffi__ZTS12ice_cpu_info_name_Set, MRB_ARGS_REQ(1));
-    mrb_define_method_f(state, Ice_cpu_infoClass, "cores", drb_ffi__ZTS12ice_cpu_info_cores_Get, MRB_ARGS_REQ(0));
-    mrb_define_method_f(state, Ice_cpu_infoClass, "cores=", drb_ffi__ZTS12ice_cpu_info_cores_Set, MRB_ARGS_REQ(1));
+    struct RClass *ice_cpu_info_class = mrb_define_class_under_f(state, module, "ICE_CPU_INFO", object_class);
+    mrb_define_class_method_f(state, ice_cpu_info_class, "new", drb_ffi__ZTS12ice_cpu_info_New, MRB_ARGS_REQ(0));
+    mrb_define_method_f(state, ice_cpu_info_class, "name", drb_ffi__ZTS12ice_cpu_info_name_Get, MRB_ARGS_REQ(0));
+    mrb_define_method_f(state, ice_cpu_info_class, "name=", drb_ffi__ZTS12ice_cpu_info_name_Set, MRB_ARGS_REQ(1));
+    mrb_define_method_f(state, ice_cpu_info_class, "cores", drb_ffi__ZTS12ice_cpu_info_cores_Get, MRB_ARGS_REQ(0));
+    mrb_define_method_f(state, ice_cpu_info_class, "cores=", drb_ffi__ZTS12ice_cpu_info_cores_Set, MRB_ARGS_REQ(1));
 }
 static int drb_ffi_init_indirect_functions(void *(*lookup)(const char *fnname)) {
   drb_symbol_lookup = lookup;

--- a/bindings/dragonruby/ice_ram_drb.c
+++ b/bindings/dragonruby/ice_ram_drb.c
@@ -67,7 +67,7 @@ static ice_ram_info *drb_ffi__ZTSP12ice_ram_info_FromRuby(mrb_state *state, mrb_
         return 0;
     struct RClass *FFI = mrb_module_get_f(state, "FFI");
     struct RClass *module = mrb_module_get_under_f(state, FFI, "CExt");
-    struct RClass *klass = mrb_class_get_under_f(state, module, "Ice_ram_infoPointer");
+    struct RClass *klass = mrb_class_get_under_f(state, module, "ICE_RAM_INFO_PTR");
     drb_typecheck_aggregate_f(state, self, klass, &ForeignObjectType_ZTSP12ice_ram_info);
     return ((struct drb_foreign_object_ZTSP12ice_ram_info *)DATA_PTR(self))->value;
 }
@@ -77,7 +77,7 @@ static mrb_value drb_ffi__ZTSP12ice_ram_info_ToRuby(mrb_state *state, ice_ram_in
     ptr->kind = drb_foreign_object_kind_pointer;
     struct RClass *FFI = mrb_module_get_f(state, "FFI");
     struct RClass *module = mrb_module_get_under_f(state, FFI, "CExt");
-    struct RClass *klass = mrb_class_get_under_f(state, module, "Ice_ram_infoPointer");
+    struct RClass *klass = mrb_class_get_under_f(state, module, "ICE_RAM_INFO_PTR");
     struct RData *rdata = mrb_data_object_alloc_f(state, klass, ptr, &ForeignObjectType_ZTSP12ice_ram_info);
     return mrb_obj_value(rdata);
 }
@@ -85,11 +85,11 @@ struct drb_foreign_object_ZTS12ice_ram_info {
     drb_foreign_object_kind kind;
     ice_ram_info value;
 };
-static mrb_data_type ForeignObjectType_ZTS12ice_ram_info = {"ice_ram_info", drb_free_foreign_object_indirect};
+static mrb_data_type ForeignObjectType_ZTS12ice_ram_info = {"ICE_RAM_INFO", drb_free_foreign_object_indirect};
 static ice_ram_info drb_ffi__ZTS12ice_ram_info_FromRuby(mrb_state *state, mrb_value self) {
     struct RClass *FFI = mrb_module_get_f(state, "FFI");
     struct RClass *module = mrb_module_get_under_f(state, FFI, "CExt");
-    struct RClass *klass = mrb_class_get_under_f(state, module, "Ice_ram_info");
+    struct RClass *klass = mrb_class_get_under_f(state, module, "ICE_RAM_INFO");
     drb_typecheck_aggregate_f(state, self, klass, &ForeignObjectType_ZTS12ice_ram_info);
     return ((struct drb_foreign_object_ZTS12ice_ram_info *)DATA_PTR(self))->value;
 }
@@ -99,7 +99,7 @@ static mrb_value drb_ffi__ZTS12ice_ram_info_ToRuby(mrb_state *state, ice_ram_inf
     ptr->kind = drb_foreign_object_kind_struct;
     struct RClass *FFI = mrb_module_get_f(state, "FFI");
     struct RClass *module = mrb_module_get_under_f(state, FFI, "CExt");
-    struct RClass *klass = mrb_class_get_under_f(state, module, "Ice_ram_info");
+    struct RClass *klass = mrb_class_get_under_f(state, module, "ICE_RAM_INFO");
     struct RData *rdata = mrb_data_object_alloc_f(state, klass, ptr, &ForeignObjectType_ZTS12ice_ram_info);
     return mrb_obj_value(rdata);
 }
@@ -117,7 +117,7 @@ static mrb_value drb_ffi__ZTSP12ice_ram_info_New(mrb_state *mrb, mrb_value self)
     ptr->should_free = 1;
     struct RClass *FFI = mrb_module_get_f(mrb, "FFI");
     struct RClass *module = mrb_module_get_under_f(mrb, FFI, "CExt");
-    struct RClass *klass = mrb_class_get_under_f(mrb, module, "Ice_ram_infoPointer");
+    struct RClass *klass = mrb_class_get_under_f(mrb, module, "ICE_RAM_INFO_PTR");
     struct RData *rdata = mrb_data_object_alloc_f(mrb, klass, ptr, &ForeignObjectType_ZTSP12ice_ram_info);
     return mrb_obj_value(rdata);
 }
@@ -150,7 +150,7 @@ static mrb_value drb_ffi__ZTS12ice_ram_info_New(mrb_state *state, mrb_value self
     struct drb_foreign_object_ZTS12ice_ram_info *ptr = calloc(1, sizeof(struct drb_foreign_object_ZTS12ice_ram_info *));
     struct RClass *FFI = mrb_module_get_f(state, "FFI");
     struct RClass *module = mrb_module_get_under_f(state, FFI, "CExt");
-    struct RClass *klass = mrb_class_get_under_f(state, module, "Ice_ram_info");
+    struct RClass *klass = mrb_class_get_under_f(state, module, "ICE_RAM_INFO");
     struct RData *rdata = mrb_data_object_alloc_f(state, klass, ptr, &ForeignObjectType_ZTS12ice_ram_info);
     return mrb_obj_value(rdata);
 }
@@ -208,20 +208,20 @@ void drb_register_c_extensions(void *(*lookup)(const char *), mrb_state *state, 
     struct RClass *module = mrb_define_module_under_f(state, FFI, "CExt");
     struct RClass *object_class = state->object_class;
     mrb_define_module_function_f(state, module, "ice_ram_get_info", drb_ffi_ice_ram_get_info_Binding, MRB_ARGS_REQ(1));
-    struct RClass *Ice_ram_infoPointerClass = mrb_define_class_under_f(state, module, "Ice_ram_infoPointer", object_class);
-    mrb_define_class_method_f(state, Ice_ram_infoPointerClass, "new", drb_ffi__ZTSP12ice_ram_info_New, MRB_ARGS_REQ(0));
-    mrb_define_method_f(state, Ice_ram_infoPointerClass, "value", drb_ffi__ZTSP12ice_ram_info_GetValue, MRB_ARGS_REQ(0));
-    mrb_define_method_f(state, Ice_ram_infoPointerClass, "[]", drb_ffi__ZTSP12ice_ram_info_GetAt, MRB_ARGS_REQ(1));
-    mrb_define_method_f(state, Ice_ram_infoPointerClass, "[]=", drb_ffi__ZTSP12ice_ram_info_SetAt, MRB_ARGS_REQ(2));
-    mrb_define_method_f(state, Ice_ram_infoPointerClass, "nil?", drb_ffi__ZTSP12ice_ram_info_IsNil, MRB_ARGS_REQ(0));
-    struct RClass *Ice_ram_infoClass = mrb_define_class_under_f(state, module, "Ice_ram_info", object_class);
-    mrb_define_class_method_f(state, Ice_ram_infoClass, "new", drb_ffi__ZTS12ice_ram_info_New, MRB_ARGS_REQ(0));
-    mrb_define_method_f(state, Ice_ram_infoClass, "free", drb_ffi__ZTS12ice_ram_info_free_Get, MRB_ARGS_REQ(0));
-    mrb_define_method_f(state, Ice_ram_infoClass, "free=", drb_ffi__ZTS12ice_ram_info_free_Set, MRB_ARGS_REQ(1));
-    mrb_define_method_f(state, Ice_ram_infoClass, "used", drb_ffi__ZTS12ice_ram_info_used_Get, MRB_ARGS_REQ(0));
-    mrb_define_method_f(state, Ice_ram_infoClass, "used=", drb_ffi__ZTS12ice_ram_info_used_Set, MRB_ARGS_REQ(1));
-    mrb_define_method_f(state, Ice_ram_infoClass, "total", drb_ffi__ZTS12ice_ram_info_total_Get, MRB_ARGS_REQ(0));
-    mrb_define_method_f(state, Ice_ram_infoClass, "total=", drb_ffi__ZTS12ice_ram_info_total_Set, MRB_ARGS_REQ(1));
+    struct RClass *ice_ram_info_ptr_class = mrb_define_class_under_f(state, module, "ICE_RAM_INFO_PTR", object_class);
+    mrb_define_class_method_f(state, ice_ram_info_ptr_class, "new", drb_ffi__ZTSP12ice_ram_info_New, MRB_ARGS_REQ(0));
+    mrb_define_method_f(state, ice_ram_info_ptr_class, "value", drb_ffi__ZTSP12ice_ram_info_GetValue, MRB_ARGS_REQ(0));
+    mrb_define_method_f(state, ice_ram_info_ptr_class, "[]", drb_ffi__ZTSP12ice_ram_info_GetAt, MRB_ARGS_REQ(1));
+    mrb_define_method_f(state, ice_ram_info_ptr_class, "[]=", drb_ffi__ZTSP12ice_ram_info_SetAt, MRB_ARGS_REQ(2));
+    mrb_define_method_f(state, ice_ram_info_ptr_class, "nil?", drb_ffi__ZTSP12ice_ram_info_IsNil, MRB_ARGS_REQ(0));
+    struct RClass *ice_ram_info_class = mrb_define_class_under_f(state, module, "ICE_RAM_INFO", object_class);
+    mrb_define_class_method_f(state, ice_ram_info_class, "new", drb_ffi__ZTS12ice_ram_info_New, MRB_ARGS_REQ(0));
+    mrb_define_method_f(state, ice_ram_info_class, "free", drb_ffi__ZTS12ice_ram_info_free_Get, MRB_ARGS_REQ(0));
+    mrb_define_method_f(state, ice_ram_info_class, "free=", drb_ffi__ZTS12ice_ram_info_free_Set, MRB_ARGS_REQ(1));
+    mrb_define_method_f(state, ice_ram_info_class, "used", drb_ffi__ZTS12ice_ram_info_used_Get, MRB_ARGS_REQ(0));
+    mrb_define_method_f(state, ice_ram_info_class, "used=", drb_ffi__ZTS12ice_ram_info_used_Set, MRB_ARGS_REQ(1));
+    mrb_define_method_f(state, ice_ram_info_class, "total", drb_ffi__ZTS12ice_ram_info_total_Get, MRB_ARGS_REQ(0));
+    mrb_define_method_f(state, ice_ram_info_class, "total=", drb_ffi__ZTS12ice_ram_info_total_Set, MRB_ARGS_REQ(1));
 }
 static int drb_ffi_init_indirect_functions(void *(*lookup)(const char *fnname)) {
   drb_symbol_lookup = lookup;

--- a/bindings/dragonruby/ice_time_drb.c
+++ b/bindings/dragonruby/ice_time_drb.c
@@ -60,11 +60,11 @@ struct drb_foreign_object_ZTS13ice_time_info {
     drb_foreign_object_kind kind;
     ice_time_info value;
 };
-static mrb_data_type ForeignObjectType_ZTS13ice_time_info = {"ice_time_info", drb_free_foreign_object_indirect};
+static mrb_data_type ForeignObjectType_ZTS13ice_time_info = {"ICE_TIME_INFO", drb_free_foreign_object_indirect};
 static ice_time_info drb_ffi__ZTS13ice_time_info_FromRuby(mrb_state *state, mrb_value self) {
     struct RClass *FFI = mrb_module_get_f(state, "FFI");
     struct RClass *module = mrb_module_get_under_f(state, FFI, "CExt");
-    struct RClass *klass = mrb_class_get_under_f(state, module, "Ice_time_info");
+    struct RClass *klass = mrb_class_get_under_f(state, module, "ICE_TIME_INFO");
     drb_typecheck_aggregate_f(state, self, klass, &ForeignObjectType_ZTS13ice_time_info);
     return ((struct drb_foreign_object_ZTS13ice_time_info *)DATA_PTR(self))->value;
 }
@@ -74,7 +74,7 @@ static mrb_value drb_ffi__ZTS13ice_time_info_ToRuby(mrb_state *state, ice_time_i
     ptr->kind = drb_foreign_object_kind_struct;
     struct RClass *FFI = mrb_module_get_f(state, "FFI");
     struct RClass *module = mrb_module_get_under_f(state, FFI, "CExt");
-    struct RClass *klass = mrb_class_get_under_f(state, module, "Ice_time_info");
+    struct RClass *klass = mrb_class_get_under_f(state, module, "ICE_TIME_INFO");
     struct RData *rdata = mrb_data_object_alloc_f(state, klass, ptr, &ForeignObjectType_ZTS13ice_time_info);
     return mrb_obj_value(rdata);
 }
@@ -103,7 +103,7 @@ static ice_time_info *drb_ffi__ZTSP13ice_time_info_FromRuby(mrb_state *state, mr
         return 0;
     struct RClass *FFI = mrb_module_get_f(state, "FFI");
     struct RClass *module = mrb_module_get_under_f(state, FFI, "CExt");
-    struct RClass *klass = mrb_class_get_under_f(state, module, "Ice_time_infoPointer");
+    struct RClass *klass = mrb_class_get_under_f(state, module, "ICE_TIME_INFO_PTR");
     drb_typecheck_aggregate_f(state, self, klass, &ForeignObjectType_ZTSP13ice_time_info);
     return ((struct drb_foreign_object_ZTSP13ice_time_info *)DATA_PTR(self))->value;
 }
@@ -113,7 +113,7 @@ static mrb_value drb_ffi__ZTSP13ice_time_info_ToRuby(mrb_state *state, ice_time_
     ptr->kind = drb_foreign_object_kind_pointer;
     struct RClass *FFI = mrb_module_get_f(state, "FFI");
     struct RClass *module = mrb_module_get_under_f(state, FFI, "CExt");
-    struct RClass *klass = mrb_class_get_under_f(state, module, "Ice_time_infoPointer");
+    struct RClass *klass = mrb_class_get_under_f(state, module, "ICE_TIME_INFO_PTR");
     struct RData *rdata = mrb_data_object_alloc_f(state, klass, ptr, &ForeignObjectType_ZTSP13ice_time_info);
     return mrb_obj_value(rdata);
 }
@@ -186,7 +186,7 @@ static mrb_value drb_ffi__ZTSP13ice_time_info_New(mrb_state *mrb, mrb_value self
     ptr->should_free = 1;
     struct RClass *FFI = mrb_module_get_f(mrb, "FFI");
     struct RClass *module = mrb_module_get_under_f(mrb, FFI, "CExt");
-    struct RClass *klass = mrb_class_get_under_f(mrb, module, "Ice_time_infoPointer");
+    struct RClass *klass = mrb_class_get_under_f(mrb, module, "ICE_TIME_INFO_PTR");
     struct RData *rdata = mrb_data_object_alloc_f(mrb, klass, ptr, &ForeignObjectType_ZTSP13ice_time_info);
     return mrb_obj_value(rdata);
 }
@@ -258,7 +258,7 @@ static mrb_value drb_ffi__ZTS13ice_time_info_New(mrb_state *state, mrb_value sel
     struct drb_foreign_object_ZTS13ice_time_info *ptr = calloc(1, sizeof(struct drb_foreign_object_ZTS13ice_time_info *));
     struct RClass *FFI = mrb_module_get_f(state, "FFI");
     struct RClass *module = mrb_module_get_under_f(state, FFI, "CExt");
-    struct RClass *klass = mrb_class_get_under_f(state, module, "Ice_time_info");
+    struct RClass *klass = mrb_class_get_under_f(state, module, "ICE_TIME_INFO");
     struct RData *rdata = mrb_data_object_alloc_f(state, klass, ptr, &ForeignObjectType_ZTS13ice_time_info);
     return mrb_obj_value(rdata);
 }
@@ -702,12 +702,12 @@ void drb_register_c_extensions(void *(*lookup)(const char *), mrb_state *state, 
     mrb_define_module_function_f(state, module, "ice_time_sec_to_ns", drb_ffi_ice_time_sec_to_ns_Binding, MRB_ARGS_REQ(1));
     mrb_define_module_function_f(state, module, "ice_time_sec_to_us", drb_ffi_ice_time_sec_to_us_Binding, MRB_ARGS_REQ(1));
     mrb_define_module_function_f(state, module, "ice_time_sec_to_ms", drb_ffi_ice_time_sec_to_ms_Binding, MRB_ARGS_REQ(1));
-    struct RClass *Ice_time_infoPointerClass = mrb_define_class_under_f(state, module, "Ice_time_infoPointer", object_class);
-    mrb_define_class_method_f(state, Ice_time_infoPointerClass, "new", drb_ffi__ZTSP13ice_time_info_New, MRB_ARGS_REQ(0));
-    mrb_define_method_f(state, Ice_time_infoPointerClass, "value", drb_ffi__ZTSP13ice_time_info_GetValue, MRB_ARGS_REQ(0));
-    mrb_define_method_f(state, Ice_time_infoPointerClass, "[]", drb_ffi__ZTSP13ice_time_info_GetAt, MRB_ARGS_REQ(1));
-    mrb_define_method_f(state, Ice_time_infoPointerClass, "[]=", drb_ffi__ZTSP13ice_time_info_SetAt, MRB_ARGS_REQ(2));
-    mrb_define_method_f(state, Ice_time_infoPointerClass, "nil?", drb_ffi__ZTSP13ice_time_info_IsNil, MRB_ARGS_REQ(0));
+    struct RClass *ice_time_info_ptr_class = mrb_define_class_under_f(state, module, "ICE_TIME_INFO_PTR", object_class);
+    mrb_define_class_method_f(state, ice_time_info_ptr_class, "new", drb_ffi__ZTSP13ice_time_info_New, MRB_ARGS_REQ(0));
+    mrb_define_method_f(state, ice_time_info_ptr_class, "value", drb_ffi__ZTSP13ice_time_info_GetValue, MRB_ARGS_REQ(0));
+    mrb_define_method_f(state, ice_time_info_ptr_class, "[]", drb_ffi__ZTSP13ice_time_info_GetAt, MRB_ARGS_REQ(1));
+    mrb_define_method_f(state, ice_time_info_ptr_class, "[]=", drb_ffi__ZTSP13ice_time_info_SetAt, MRB_ARGS_REQ(2));
+    mrb_define_method_f(state, ice_time_info_ptr_class, "nil?", drb_ffi__ZTSP13ice_time_info_IsNil, MRB_ARGS_REQ(0));
     struct RClass *CharPointerClass = mrb_define_class_under_f(state, module, "CharPointer", object_class);
     mrb_define_class_method_f(state, CharPointerClass, "new", drb_ffi__ZTSPc_New, MRB_ARGS_REQ(0));
     mrb_define_method_f(state, CharPointerClass, "value", drb_ffi__ZTSPc_GetValue, MRB_ARGS_REQ(0));
@@ -715,34 +715,34 @@ void drb_register_c_extensions(void *(*lookup)(const char *), mrb_state *state, 
     mrb_define_method_f(state, CharPointerClass, "[]=", drb_ffi__ZTSPc_SetAt, MRB_ARGS_REQ(2));
     mrb_define_method_f(state, CharPointerClass, "nil?", drb_ffi__ZTSPc_IsNil, MRB_ARGS_REQ(0));
     mrb_define_method_f(state, CharPointerClass, "str", drb_ffi__ZTSPc_GetString, MRB_ARGS_REQ(0));
-    struct RClass *Ice_time_infoClass = mrb_define_class_under_f(state, module, "Ice_time_info", object_class);
-    mrb_define_class_method_f(state, Ice_time_infoClass, "new", drb_ffi__ZTS13ice_time_info_New, MRB_ARGS_REQ(0));
-    mrb_define_method_f(state, Ice_time_infoClass, "str", drb_ffi__ZTS13ice_time_info_str_Get, MRB_ARGS_REQ(0));
-    mrb_define_method_f(state, Ice_time_infoClass, "str=", drb_ffi__ZTS13ice_time_info_str_Set, MRB_ARGS_REQ(1));
-    mrb_define_method_f(state, Ice_time_infoClass, "clock_ticks", drb_ffi__ZTS13ice_time_info_clock_ticks_Get, MRB_ARGS_REQ(0));
-    mrb_define_method_f(state, Ice_time_infoClass, "clock_ticks=", drb_ffi__ZTS13ice_time_info_clock_ticks_Set, MRB_ARGS_REQ(1));
-    mrb_define_method_f(state, Ice_time_infoClass, "uptime", drb_ffi__ZTS13ice_time_info_uptime_Get, MRB_ARGS_REQ(0));
-    mrb_define_method_f(state, Ice_time_infoClass, "uptime=", drb_ffi__ZTS13ice_time_info_uptime_Set, MRB_ARGS_REQ(1));
-    mrb_define_method_f(state, Ice_time_infoClass, "epoch", drb_ffi__ZTS13ice_time_info_epoch_Get, MRB_ARGS_REQ(0));
-    mrb_define_method_f(state, Ice_time_infoClass, "epoch=", drb_ffi__ZTS13ice_time_info_epoch_Set, MRB_ARGS_REQ(1));
-    mrb_define_method_f(state, Ice_time_infoClass, "seconds", drb_ffi__ZTS13ice_time_info_seconds_Get, MRB_ARGS_REQ(0));
-    mrb_define_method_f(state, Ice_time_infoClass, "seconds=", drb_ffi__ZTS13ice_time_info_seconds_Set, MRB_ARGS_REQ(1));
-    mrb_define_method_f(state, Ice_time_infoClass, "minutes", drb_ffi__ZTS13ice_time_info_minutes_Get, MRB_ARGS_REQ(0));
-    mrb_define_method_f(state, Ice_time_infoClass, "minutes=", drb_ffi__ZTS13ice_time_info_minutes_Set, MRB_ARGS_REQ(1));
-    mrb_define_method_f(state, Ice_time_infoClass, "hour", drb_ffi__ZTS13ice_time_info_hour_Get, MRB_ARGS_REQ(0));
-    mrb_define_method_f(state, Ice_time_infoClass, "hour=", drb_ffi__ZTS13ice_time_info_hour_Set, MRB_ARGS_REQ(1));
-    mrb_define_method_f(state, Ice_time_infoClass, "week_day", drb_ffi__ZTS13ice_time_info_week_day_Get, MRB_ARGS_REQ(0));
-    mrb_define_method_f(state, Ice_time_infoClass, "week_day=", drb_ffi__ZTS13ice_time_info_week_day_Set, MRB_ARGS_REQ(1));
-    mrb_define_method_f(state, Ice_time_infoClass, "month_day", drb_ffi__ZTS13ice_time_info_month_day_Get, MRB_ARGS_REQ(0));
-    mrb_define_method_f(state, Ice_time_infoClass, "month_day=", drb_ffi__ZTS13ice_time_info_month_day_Set, MRB_ARGS_REQ(1));
-    mrb_define_method_f(state, Ice_time_infoClass, "year_day", drb_ffi__ZTS13ice_time_info_year_day_Get, MRB_ARGS_REQ(0));
-    mrb_define_method_f(state, Ice_time_infoClass, "year_day=", drb_ffi__ZTS13ice_time_info_year_day_Set, MRB_ARGS_REQ(1));
-    mrb_define_method_f(state, Ice_time_infoClass, "month", drb_ffi__ZTS13ice_time_info_month_Get, MRB_ARGS_REQ(0));
-    mrb_define_method_f(state, Ice_time_infoClass, "month=", drb_ffi__ZTS13ice_time_info_month_Set, MRB_ARGS_REQ(1));
-    mrb_define_method_f(state, Ice_time_infoClass, "season", drb_ffi__ZTS13ice_time_info_season_Get, MRB_ARGS_REQ(0));
-    mrb_define_method_f(state, Ice_time_infoClass, "season=", drb_ffi__ZTS13ice_time_info_season_Set, MRB_ARGS_REQ(1));
-    mrb_define_method_f(state, Ice_time_infoClass, "year", drb_ffi__ZTS13ice_time_info_year_Get, MRB_ARGS_REQ(0));
-    mrb_define_method_f(state, Ice_time_infoClass, "year=", drb_ffi__ZTS13ice_time_info_year_Set, MRB_ARGS_REQ(1));
+    struct RClass *ice_time_infoClass = mrb_define_class_under_f(state, module, "ICE_TIME_INFO", object_class);
+    mrb_define_class_method_f(state, ice_time_infoClass, "new", drb_ffi__ZTS13ice_time_info_New, MRB_ARGS_REQ(0));
+    mrb_define_method_f(state, ice_time_infoClass, "str", drb_ffi__ZTS13ice_time_info_str_Get, MRB_ARGS_REQ(0));
+    mrb_define_method_f(state, ice_time_infoClass, "str=", drb_ffi__ZTS13ice_time_info_str_Set, MRB_ARGS_REQ(1));
+    mrb_define_method_f(state, ice_time_infoClass, "clock_ticks", drb_ffi__ZTS13ice_time_info_clock_ticks_Get, MRB_ARGS_REQ(0));
+    mrb_define_method_f(state, ice_time_infoClass, "clock_ticks=", drb_ffi__ZTS13ice_time_info_clock_ticks_Set, MRB_ARGS_REQ(1));
+    mrb_define_method_f(state, ice_time_infoClass, "uptime", drb_ffi__ZTS13ice_time_info_uptime_Get, MRB_ARGS_REQ(0));
+    mrb_define_method_f(state, ice_time_infoClass, "uptime=", drb_ffi__ZTS13ice_time_info_uptime_Set, MRB_ARGS_REQ(1));
+    mrb_define_method_f(state, ice_time_infoClass, "epoch", drb_ffi__ZTS13ice_time_info_epoch_Get, MRB_ARGS_REQ(0));
+    mrb_define_method_f(state, ice_time_infoClass, "epoch=", drb_ffi__ZTS13ice_time_info_epoch_Set, MRB_ARGS_REQ(1));
+    mrb_define_method_f(state, ice_time_infoClass, "seconds", drb_ffi__ZTS13ice_time_info_seconds_Get, MRB_ARGS_REQ(0));
+    mrb_define_method_f(state, ice_time_infoClass, "seconds=", drb_ffi__ZTS13ice_time_info_seconds_Set, MRB_ARGS_REQ(1));
+    mrb_define_method_f(state, ice_time_infoClass, "minutes", drb_ffi__ZTS13ice_time_info_minutes_Get, MRB_ARGS_REQ(0));
+    mrb_define_method_f(state, ice_time_infoClass, "minutes=", drb_ffi__ZTS13ice_time_info_minutes_Set, MRB_ARGS_REQ(1));
+    mrb_define_method_f(state, ice_time_infoClass, "hour", drb_ffi__ZTS13ice_time_info_hour_Get, MRB_ARGS_REQ(0));
+    mrb_define_method_f(state, ice_time_infoClass, "hour=", drb_ffi__ZTS13ice_time_info_hour_Set, MRB_ARGS_REQ(1));
+    mrb_define_method_f(state, ice_time_infoClass, "week_day", drb_ffi__ZTS13ice_time_info_week_day_Get, MRB_ARGS_REQ(0));
+    mrb_define_method_f(state, ice_time_infoClass, "week_day=", drb_ffi__ZTS13ice_time_info_week_day_Set, MRB_ARGS_REQ(1));
+    mrb_define_method_f(state, ice_time_infoClass, "month_day", drb_ffi__ZTS13ice_time_info_month_day_Get, MRB_ARGS_REQ(0));
+    mrb_define_method_f(state, ice_time_infoClass, "month_day=", drb_ffi__ZTS13ice_time_info_month_day_Set, MRB_ARGS_REQ(1));
+    mrb_define_method_f(state, ice_time_infoClass, "year_day", drb_ffi__ZTS13ice_time_info_year_day_Get, MRB_ARGS_REQ(0));
+    mrb_define_method_f(state, ice_time_infoClass, "year_day=", drb_ffi__ZTS13ice_time_info_year_day_Set, MRB_ARGS_REQ(1));
+    mrb_define_method_f(state, ice_time_infoClass, "month", drb_ffi__ZTS13ice_time_info_month_Get, MRB_ARGS_REQ(0));
+    mrb_define_method_f(state, ice_time_infoClass, "month=", drb_ffi__ZTS13ice_time_info_month_Set, MRB_ARGS_REQ(1));
+    mrb_define_method_f(state, ice_time_infoClass, "season", drb_ffi__ZTS13ice_time_info_season_Get, MRB_ARGS_REQ(0));
+    mrb_define_method_f(state, ice_time_infoClass, "season=", drb_ffi__ZTS13ice_time_info_season_Set, MRB_ARGS_REQ(1));
+    mrb_define_method_f(state, ice_time_infoClass, "year", drb_ffi__ZTS13ice_time_info_year_Get, MRB_ARGS_REQ(0));
+    mrb_define_method_f(state, ice_time_infoClass, "year=", drb_ffi__ZTS13ice_time_info_year_Set, MRB_ARGS_REQ(1));
 }
 static int drb_ffi_init_indirect_functions(void *(*lookup)(const char *fnname)) {
   drb_symbol_lookup = lookup;

--- a/bindings/luajit/examples/hello_ice_al.lua
+++ b/bindings/luajit/examples/hello_ice_al.lua
@@ -1,0 +1,53 @@
+local ffi = require("ffi")
+local lib = require("ice_al")
+
+-- This allows the functions of the bindings to be globally called...
+setmetatable(_G, { __index = lib })
+
+local function main()
+  local res
+  
+  -- OpenAL device and OpenAL device name
+  local device_name
+  local dev 
+
+  -- Define the path of the OpenAL shared library/object depending on the platform (NOTE: You can also use OpenAL-soft) */
+  local path
+
+  if ffi.os == "Windows" then
+    path = "OpenAL32.dll"
+  else
+    path = "./liboal.so"
+  end
+  
+  -- Load OpenAL shared library/object then load OpenAL API
+  res = ice_al_load(path)
+  
+  -- If the function failed to load OpenAL shared library and failed to load OpenAL API, Trace error then terminate the program
+  if (res == ICE_AL_FALSE) then
+    print("ERROR: failed to load OpenAL shared library/object!")
+    return -1
+  end
+  
+  -- Get the default OpenAL audio device and initialize it
+  local device_name = alcGetString(nil, ALC_DEFAULT_DEVICE_SPECIFIER)
+  local dev = alcOpenDevice(device_name)
+  
+  -- If the function failed to initialize the default OpenAL device, Trace error then terminate the program
+  if (dev == 0) then
+    print("ERROR: failed to open audio device!")
+    return -1
+  end
+  
+  print("OpenAL audio device works!")
+  
+  -- Once done close the OpenAL device, If the function failed to close the default OpenAL device, Trace error then terminate the program
+  if (alcCloseDevice(dev) == ALC_FALSE) then
+    print("ERROR: failed to close audio device!")
+    return -1
+  end
+    
+  return 0
+end
+
+return main()

--- a/bindings/luajit/examples/hello_ice_batt.lua
+++ b/bindings/luajit/examples/hello_ice_batt.lua
@@ -1,0 +1,28 @@
+local ffi = require("ffi")
+local lib = require("ice_batt")
+
+-- This allows the functions of the bindings to be globally called...
+setmetatable(_G, { __index = lib })
+
+local function main()
+  -- Struct that contains information about the battery
+  local batt = ffi.new("ice_batt_info")
+  
+  -- Fetch battery information and store the information in the struct
+  local err = ice_batt_get_info(batt)
+  
+  -- If the function failed to fetch battery information, Trace error then terminate the program
+  if (err ~= ICE_BATT_ERROR_OK) then
+    print("ERROR: failed to fetch battery information!")
+    return -1
+  end
+  
+  -- Print the informations
+  print("Device has battery: " .. ((batt.exists == ICE_BATT_TRUE) and "YES" or "NO") ..
+        "\nIs battery charging: " .. ((batt.charging == ICE_BATT_TRUE) and "YES" or "NO") ..
+        "\nBattery Level: " .. batt.level)
+  
+  return 0
+end
+
+return main()

--- a/bindings/luajit/examples/hello_ice_clip.lua
+++ b/bindings/luajit/examples/hello_ice_clip.lua
@@ -1,0 +1,47 @@
+local ffi = require("ffi")
+local lib = require("ice_clip")
+
+-- This allows the functions of the bindings to be globally called...
+setmetatable(_G, { __index = lib })
+
+local function main()
+  -- To store result of called functions
+  local res
+  
+  -- String to copy to clipboard later...
+  local str = "SPEED!"
+  
+  -- Retrieve the clipboard text
+  local text = ice_clip_get()
+  
+  -- If the function failed to retrieve Clipboard text or Clipboard has no text then trace log a note, Else print the retrieved text...
+  if (text == nil) then
+    print("LOG: failed to retrieve Clipboard text, Maybe the Clipboard does not contain text?")
+  else
+    print("Text from the Clipboard: " .. ffi.string(text))
+  end
+  
+  -- Clear the Clipboard
+  res = ice_clip_clear()
+  
+  -- If the function failed to clear the Clipboard, Trace error then terminate the program
+  if (res == ICE_CLIP_FALSE) then
+    print("ERROR: failed to clear the Clipboard!")
+    return -1
+  end
+  
+  -- Copy text to Clipboard
+  res = ice_clip_set(str)
+  
+  -- If the function failed to copy text to the Clipboard, Trace error then terminate the program
+  if (res == ICE_CLIP_FALSE) then
+    print("ERROR: Failed to copy text to Clipboard!")
+    return -1
+  end
+    
+  print("Text copied to the Clipboard: " .. str)
+
+  return 0
+end
+
+return main()

--- a/bindings/luajit/examples/hello_ice_cpu.lua
+++ b/bindings/luajit/examples/hello_ice_cpu.lua
@@ -1,0 +1,26 @@
+local ffi = require("ffi")
+local lib = require("ice_cpu")
+
+-- This allows the functions of the bindings to be globally called...
+setmetatable(_G, { __index = lib })
+
+local function main()
+  -- Struct that contains CPU information
+  local cpu = ffi.new("ice_cpu_info")
+  
+  -- Get CPU information
+  local res = ice_cpu_get_info(cpu)
+  
+  -- If the function failed to retrieve CPU information, Trace error then terminate the program
+  if (res == ICE_CPU_FALSE) then
+    print("ERROR: failed to retrieve CPU information!")
+    return -1
+  end
+  
+  -- Print the informations
+  print("CPU Name: " .. ffi.string(cpu.name) .. "\nCPU Cores: " .. cpu.cores)
+  
+  return 0
+end
+
+return main()

--- a/bindings/luajit/examples/hello_ice_ease.lua
+++ b/bindings/luajit/examples/hello_ice_ease.lua
@@ -1,0 +1,19 @@
+local lib = require("ice_ease")
+
+-- This allows the functions of the bindings to be globally called...
+setmetatable(_G, { __index = lib })
+
+local function main()
+  -- Use linear easing, With 1 argument (easings.net)
+  local linear1 = ice_ease_linear(ICE_EASE_TYPE_PROGRESS, 5.0)
+  
+  -- Use linear easing, But with 4 arguments (Robert Penner's version)
+  local linear4 = ice_ease_linear(ICE_EASE_TYPE_PENNER, 1.0, 2.0, 3.0, 4.0)
+  
+  -- Print the results...
+  print("Linear easing with one variable: " .. linear1 .. "\nLinear easing with four variables: " .. linear4)
+  
+  return 0
+end
+
+return main()

--- a/bindings/luajit/examples/hello_ice_ffi.lua
+++ b/bindings/luajit/examples/hello_ice_ffi.lua
@@ -1,0 +1,60 @@
+local ffi = require("ffi")
+local lib = require("ice_ffi")
+
+-- This allows the functions of the bindings to be globally called...
+setmetatable(_G, { __index = lib })
+
+local function main()
+  -- To store result of unloading the shared library/object
+  local unload_res
+  
+  -- Handle for shared library/object
+  local lib
+  
+  -- function from shared library/object
+  local F42
+  
+  -- Define path of the shared library/object depending on platform
+  local path
+
+  if ffi.os == "Windows" then
+    path = "lib42.dll"
+  else
+    path = "./lib42.so"
+  end
+  
+  -- Load the shared library/object
+  lib = ice_ffi_load(path)
+  
+  -- If the function failed to load the shared library/object, Trace error then terminate the program
+  if (lib == nil) then
+    print("ERROR: failed to load shared library/object!")
+    return -1
+  end
+  
+  -- If the shared library/object loaded successfully, Get the function F42 symbol to call it!
+  F42 = ffi.cast("unsigned (*)(void)", ice_ffi_get(lib, "F42"))
+  
+  -- If the function failed to get symbol from shared library/object, Trace error then terminate the program
+  if (F42 == nil) then
+    print("ERROR: failed to get symbol from shared library/object!")
+    return -1
+  end
+  
+  -- Call the function and print the result!
+  print("F42 call result: " .. tonumber(F42()))
+  
+  -- When done, Unload symbols and the shared library/object
+  F42 = nil
+  unload_res = ice_ffi_unload(lib)
+  
+  -- If the function failed to unload shared library/object, Trace error then terminate the program
+  if (unload_res == ICE_FFI_FALSE) then
+    print("ERROR: failed to unload shared library/object!")
+    return -1
+  end
+  
+  return 0
+end
+
+return main()

--- a/bindings/luajit/examples/hello_ice_ram.lua
+++ b/bindings/luajit/examples/hello_ice_ram.lua
@@ -1,0 +1,28 @@
+local ffi = require("ffi")
+local lib = require("ice_ram")
+
+-- This allows the functions of the bindings to be globally called...
+setmetatable(_G, { __index = lib })
+
+local function main()
+  -- Struct that contains RAM information
+  local ram = ffi.new("ice_ram_info")
+
+  -- Fetch RAM info
+  local res = ice_ram_get_info(ram)
+  
+  -- If function failed to fetch RAM info, Trace error then terminate the program
+  if (res == ICE_RAM_FALSE) then
+    print("ERROR: failed to get RAM info!")
+    return -1
+  end
+  
+  -- Print RAM info (free, used, total) in bytes
+  print("Free RAM: " .. tonumber(ram.free) .. " bytes\n" ..
+        "Used RAM: " .. tonumber(ram.used) .. " bytes\n" ..
+        "Total RAM: " .. tonumber(ram.total) .. " bytes")
+
+  return 0
+end
+
+return main()

--- a/bindings/luajit/examples/hello_ice_str.lua
+++ b/bindings/luajit/examples/hello_ice_str.lua
@@ -1,0 +1,24 @@
+local ffi = require("ffi")
+local lib = require("ice_str")
+
+-- This allows the functions of the bindings to be globally called...
+setmetatable(_G, { __index = lib })
+
+local function main()
+  -- Create a string repeated for multiple times
+  local haha = ice_str_dup("HA", 8) -- HAHAHAHAHAHAHAHA
+  
+  -- If the function failed to allocate string, Trace error then terminate the program
+  if (haha == 0) then
+    print("ERROR: failed to allocate string!")
+    return -1
+  end
+  
+  -- Print the string, Once we done we deallocate/free the string
+  print(ffi.string(haha))
+  ice_str_free(haha)
+  
+  return 0
+end
+
+return main()

--- a/bindings/luajit/examples/hello_ice_time.lua
+++ b/bindings/luajit/examples/hello_ice_time.lua
@@ -1,0 +1,26 @@
+local ffi = require("ffi")
+local lib = require("ice_time")
+
+-- This allows the functions of the bindings to be globally called...
+setmetatable(_G, { __index = lib })
+
+local function main()
+  -- Struct that contains Time information
+  local current_time = ffi.new("ice_time_info")
+  
+  -- Fetch time information and store it in the struct
+  local res = ice_time_get_info(current_time)
+  
+  -- If the function failed to fetch time information, Trace error then terminate the program!
+  if (res ~= ICE_TIME_ERROR_OK) then
+    print("ERROR: failed to get time info!")
+    return -1
+  end
+  
+  -- Print current time!
+  print("Current Time: " .. ffi.string(current_time.str))
+  
+  return 0
+end
+
+return main()

--- a/bindings/luajit/ice_al.lua
+++ b/bindings/luajit/ice_al.lua
@@ -1,7 +1,6 @@
 local ffi = require("ffi")
 local ffi_load = ffi.load
 local ffi_cdef = ffi.cdef
-local _setmetatable = setmetatable
 
 ffi_cdef([[
 /* ============================= Data Types (OpenAL API) ============================= */
@@ -138,99 +137,99 @@ enum {
 
 /* ============================= Functions (OpenAL API) ============================= */
 
-void alDopplerFactor(ALfloat value);
-void alSpeedOfSound(ALfloat value);
-void alDistanceModel(ALenum distanceModel);
-void alEnable(ALenum capability);
-void alDisable(ALenum capability);
-ALboolean alIsEnabled(ALenum capability);
-const ALchar * alGetString(ALenum param);
-void alGetBooleanv(ALenum param, ALboolean *values);
-void alGetIntegerv(ALenum param, ALint *values);
-void alGetFloatv(ALenum param, ALfloat *values);
-void alGetDoublev(ALenum param, ALdouble *values);
-ALboolean alGetBoolean(ALenum param);
-ALint alGetInteger(ALenum param);
-ALfloat alGetFloat(ALenum param);
-ALdouble alGetDouble(ALenum param);
-ALenum alGetError(void);
-ALboolean alIsExtensionPresent(const ALchar *extname);
-void* alGetProcAddress(const ALchar *fname);
-ALenum alGetEnumValue(const ALchar *ename);
-void alListenerf(ALenum param, ALfloat value);
-void alListener3f(ALenum param, ALfloat value1, ALfloat value2, ALfloat value3);
-void alListenerfv(ALenum param, const ALfloat *values);
-void alListeneri(ALenum param, ALint value);
-void alListener3i(ALenum param, ALint value1, ALint value2, ALint value3);
-void alListeneriv(ALenum param, const ALint *values);
-void alGetListenerf(ALenum param, ALfloat *value);
-void alGetListener3f(ALenum param, ALfloat *value1, ALfloat *value2, ALfloat *value3);
-void alGetListenerfv(ALenum param, ALfloat *values);
-void alGetListeneri(ALenum param, ALint *value);
-void alGetListener3i(ALenum param, ALint *value1, ALint *value2, ALint *value3);
-void alGetListeneriv(ALenum param, ALint *values);
-void alGenSources(ALsizei n, ALuint *sources);
-void alDeleteSources(ALsizei n, const ALuint *sources);
-ALboolean alIsSource(ALuint source);
-void alSourcef(ALuint source, ALenum param, ALfloat value);
-void alSource3f(ALuint source, ALenum param, ALfloat value1, ALfloat value2, ALfloat value3);
-void alSourcefv(ALuint source, ALenum param, const ALfloat *values);
-void alSourcei(ALuint source, ALenum param, ALint value);
-void alSource3i(ALuint source, ALenum param, ALint value1, ALint value2, ALint value3);
-void alSourceiv(ALuint source, ALenum param, const ALint *values);
-void alGetSourcef(ALuint source, ALenum param, ALfloat *value);
-void alGetSource3f(ALuint source, ALenum param, ALfloat *value1, ALfloat *value2, ALfloat *value3);
-void alGetSourcefv(ALuint source, ALenum param, ALfloat *values);
-void alGetSourcei(ALuint source,  ALenum param, ALint *value);
-void alGetSource3i(ALuint source, ALenum param, ALint *value1, ALint *value2, ALint *value3);
-void alGetSourceiv(ALuint source,  ALenum param, ALint *values);
-void alSourcePlayv(ALsizei n, const ALuint *sources);
-void alSourceStopv(ALsizei n, const ALuint *sources);
-void alSourceRewindv(ALsizei n, const ALuint *sources);
-void alSourcePausev(ALsizei n, const ALuint *sources);
-void alSourcePlay(ALuint source);
-void alSourceStop(ALuint source);
-void alSourceRewind(ALuint source);
-void alSourcePause(ALuint source);
-void alSourceQueueBuffers(ALuint source, ALsizei nb, const ALuint *buffers);
-void alSourceUnqueueBuffers(ALuint source, ALsizei nb, ALuint *buffers);
-void alGenBuffers(ALsizei n, ALuint *buffers);
-void alDeleteBuffers(ALsizei n, const ALuint *buffers);
-ALboolean alIsBuffer(ALuint buffer);
-void alBufferData(ALuint buffer, ALenum format, const ALvoid *data, ALsizei size, ALsizei freq);
-void alBufferf(ALuint buffer, ALenum param, ALfloat value);
-void alBuffer3f(ALuint buffer, ALenum param, ALfloat value1, ALfloat value2, ALfloat value3);
-void alBufferfv(ALuint buffer, ALenum param, const ALfloat *values);
-void alBufferi(ALuint buffer, ALenum param, ALint value);
-void alBuffer3i(ALuint buffer, ALenum param, ALint value1, ALint value2, ALint value3);
-void alBufferiv(ALuint buffer, ALenum param, const ALint *values);
-void alGetBufferf(ALuint buffer, ALenum param, ALfloat *value);
-void alGetBuffer3f(ALuint buffer, ALenum param, ALfloat *value1, ALfloat *value2, ALfloat *value3);
-void alGetBufferfv(ALuint buffer, ALenum param, ALfloat *values);
-void alGetBufferi(ALuint buffer, ALenum param, ALint *value);
-void alGetBuffer3i(ALuint buffer, ALenum param, ALint *value1, ALint *value2, ALint *value3);
-void alGetBufferiv(ALuint buffer, ALenum param, ALint *values);
+void (*alDopplerFactor)(ALfloat value);
+void (*alSpeedOfSound)(ALfloat value);
+void (*alDistanceModel)(ALenum distanceModel);
+void (*alEnable)(ALenum capability);
+void (*alDisable)(ALenum capability);
+ALboolean (*alIsEnabled)(ALenum capability);
+const ALchar * (*alGetString)(ALenum param);
+void (*alGetBooleanv)(ALenum param, ALboolean *values);
+void (*alGetIntegerv)(ALenum param, ALint *values);
+void (*alGetFloatv)(ALenum param, ALfloat *values);
+void (*alGetDoublev)(ALenum param, ALdouble *values);
+ALboolean (*alGetBoolean)(ALenum param);
+ALint (*alGetInteger)(ALenum param);
+ALfloat (*alGetFloat)(ALenum param);
+ALdouble (*alGetDouble)(ALenum param);
+ALenum (*alGetError)(void);
+ALboolean (*alIsExtensionPresent)(const ALchar *extname);
+void* (*alGetProcAddress)(const ALchar *fname);
+ALenum (*alGetEnumValue)(const ALchar *ename);
+void (*alListenerf)(ALenum param, ALfloat value);
+void (*alListener3f)(ALenum param, ALfloat value1, ALfloat value2, ALfloat value3);
+void (*alListenerfv)(ALenum param, const ALfloat *values);
+void (*alListeneri)(ALenum param, ALint value);
+void (*alListener3i)(ALenum param, ALint value1, ALint value2, ALint value3);
+void (*alListeneriv)(ALenum param, const ALint *values);
+void (*alGetListenerf)(ALenum param, ALfloat *value);
+void (*alGetListener3f)(ALenum param, ALfloat *value1, ALfloat *value2, ALfloat *value3);
+void (*alGetListenerfv)(ALenum param, ALfloat *values);
+void (*alGetListeneri)(ALenum param, ALint *value);
+void (*alGetListener3i)(ALenum param, ALint *value1, ALint *value2, ALint *value3);
+void (*alGetListeneriv)(ALenum param, ALint *values);
+void (*alGenSources)(ALsizei n, ALuint *sources);
+void (*alDeleteSources)(ALsizei n, const ALuint *sources);
+ALboolean (*alIsSource)(ALuint source);
+void (*alSourcef)(ALuint source, ALenum param, ALfloat value);
+void (*alSource3f)(ALuint source, ALenum param, ALfloat value1, ALfloat value2, ALfloat value3);
+void (*alSourcefv)(ALuint source, ALenum param, const ALfloat *values);
+void (*alSourcei)(ALuint source, ALenum param, ALint value);
+void (*alSource3i)(ALuint source, ALenum param, ALint value1, ALint value2, ALint value3);
+void (*alSourceiv)(ALuint source, ALenum param, const ALint *values);
+void (*alGetSourcef)(ALuint source, ALenum param, ALfloat *value);
+void (*alGetSource3f)(ALuint source, ALenum param, ALfloat *value1, ALfloat *value2, ALfloat *value3);
+void (*alGetSourcefv)(ALuint source, ALenum param, ALfloat *values);
+void (*alGetSourcei)(ALuint source,  ALenum param, ALint *value);
+void (*alGetSource3i)(ALuint source, ALenum param, ALint *value1, ALint *value2, ALint *value3);
+void (*alGetSourceiv)(ALuint source,  ALenum param, ALint *values);
+void (*alSourcePlayv)(ALsizei n, const ALuint *sources);
+void (*alSourceStopv)(ALsizei n, const ALuint *sources);
+void (*alSourceRewindv)(ALsizei n, const ALuint *sources);
+void (*alSourcePausev)(ALsizei n, const ALuint *sources);
+void (*alSourcePlay)(ALuint source);
+void (*alSourceStop)(ALuint source);
+void (*alSourceRewind)(ALuint source);
+void (*alSourcePause)(ALuint source);
+void (*alSourceQueueBuffers)(ALuint source, ALsizei nb, const ALuint *buffers);
+void (*alSourceUnqueueBuffers)(ALuint source, ALsizei nb, ALuint *buffers);
+void (*alGenBuffers)(ALsizei n, ALuint *buffers);
+void (*alDeleteBuffers)(ALsizei n, const ALuint *buffers);
+ALboolean (*alIsBuffer)(ALuint buffer);
+void (*alBufferData)(ALuint buffer, ALenum format, const ALvoid *data, ALsizei size, ALsizei freq);
+void (*alBufferf)(ALuint buffer, ALenum param, ALfloat value);
+void (*alBuffer3f)(ALuint buffer, ALenum param, ALfloat value1, ALfloat value2, ALfloat value3);
+void (*alBufferfv)(ALuint buffer, ALenum param, const ALfloat *values);
+void (*alBufferi)(ALuint buffer, ALenum param, ALint value);
+void (*alBuffer3i)(ALuint buffer, ALenum param, ALint value1, ALint value2, ALint value3);
+void (*alBufferiv)(ALuint buffer, ALenum param, const ALint *values);
+void (*alGetBufferf)(ALuint buffer, ALenum param, ALfloat *value);
+void (*alGetBuffer3f)(ALuint buffer, ALenum param, ALfloat *value1, ALfloat *value2, ALfloat *value3);
+void (*alGetBufferfv)(ALuint buffer, ALenum param, ALfloat *values);
+void (*alGetBufferi)(ALuint buffer, ALenum param, ALint *value);
+void (*alGetBuffer3i)(ALuint buffer, ALenum param, ALint *value1, ALint *value2, ALint *value3);
+void (*alGetBufferiv)(ALuint buffer, ALenum param, ALint *values);
 
-ALCcontext* alcCreateContext(ALCdevice *device, const ALCint *attrlist);
-ALCboolean alcMakeContextCurrent(ALCcontext *context);
-void alcProcessContext(ALCcontext *context);
-void alcSuspendContext(ALCcontext *context);
-void alcDestroyContext(ALCcontext *context);
-ALCcontext* alcGetCurrentContext(void);
-ALCcontext* alcGetContextsDevice(ALCcontext *context);
-ALCdevice* alcOpenDevice(const ALCchar *devicename);
-ALCboolean alcCloseDevice(ALCdevice *device);
-ALCenum alcGetError(ALCdevice *device);
-ALCboolean alcIsExtensionPresent(ALCdevice *device, const ALCchar *extname);
-ALCvoid* alcGetProcAddress(ALCdevice *device, const ALCchar *funcname);
-ALCenum alcGetEnumValue(ALCdevice *device, const ALCchar *enumname);
-ALCchar* alcGetString(ALCdevice *device, ALCenum param);
-void alcGetIntegerv(ALCdevice *device, ALCenum param, ALCsizei size, ALCint *values);
-ALCdevice* alcCaptureOpenDevice(const ALCchar *devicename, ALCuint frequency, ALCenum format, ALCsizei buffersize);
-ALCboolean alcCaptureCloseDevice(ALCdevice *device);
-void alcCaptureStart(ALCdevice *device);
-void alcCaptureStop(ALCdevice *device);
-void alcCaptureSamples(ALCdevice *device, ALCvoid* buffer, ALCsizei samples);
+ALCcontext* (*alcCreateContext)(ALCdevice *device, const ALCint *attrlist);
+ALCboolean (*alcMakeContextCurrent)(ALCcontext *context);
+void (*alcProcessContext)(ALCcontext *context);
+void (*alcSuspendContext)(ALCcontext *context);
+void (*alcDestroyContext)(ALCcontext *context);
+ALCcontext* (*alcGetCurrentContext)(void);
+ALCcontext* (*alcGetContextsDevice)(ALCcontext *context);
+ALCdevice* (*alcOpenDevice)(const ALCchar *devicename);
+ALCboolean (*alcCloseDevice)(ALCdevice *device);
+ALCenum (*alcGetError)(ALCdevice *device);
+ALCboolean (*alcIsExtensionPresent)(ALCdevice *device, const ALCchar *extname);
+ALCvoid* (*alcGetProcAddress)(ALCdevice *device, const ALCchar *funcname);
+ALCenum (*alcGetEnumValue)(ALCdevice *device, const ALCchar *enumname);
+const ALCchar* (*alcGetString)(ALCdevice *device, ALCenum param);
+void (*alcGetIntegerv)(ALCdevice *device, ALCenum param, ALCsizei size, ALCint *values);
+ALCdevice* (*alcCaptureOpenDevice)(const ALCchar *devicename, ALCuint frequency, ALCenum format, ALCsizei buffersize);
+ALCboolean (*alcCaptureCloseDevice)(ALCdevice *device);
+void (*alcCaptureStart)(ALCdevice *device);
+void (*alcCaptureStop)(ALCdevice *device);
+void (*alcCaptureSamples)(ALCdevice *device, ALCvoid* buffer, ALCsizei samples);
 
 /* ============================= Data Types ============================= */
 
@@ -255,5 +254,4 @@ ice_al_bool ice_al_load(const char *path);
 ice_al_bool ice_al_unload(void);
 ]])
 
-local lib = ffi_load("ice_al")
-_setmetatable(_G, { __index = lib })
+return ffi_load("ice_al")

--- a/bindings/luajit/ice_batt.lua
+++ b/bindings/luajit/ice_batt.lua
@@ -1,7 +1,6 @@
 local ffi = require("ffi")
 local ffi_load = ffi.load
 local ffi_cdef = ffi.cdef
-local _setmetatable = setmetatable
 
 ffi_cdef([[
 /* ============================== Data Types ============================== */
@@ -34,5 +33,4 @@ void ice_batt_use_native_activity(void *activity);
 ice_batt_error ice_batt_get_info(ice_batt_info *batt_info);
 ]])
 
-local lib = ffi_load("ice_batt")
-_setmetatable(_G, { __index = lib })
+return ffi_load("ice_batt")

--- a/bindings/luajit/ice_clip.lua
+++ b/bindings/luajit/ice_clip.lua
@@ -1,7 +1,6 @@
 local ffi = require("ffi")
 local ffi_load = ffi.load
 local ffi_cdef = ffi.cdef
-local _setmetatable = setmetatable
 
 ffi_cdef([[
 /* ============================== Data Types ============================== */
@@ -30,5 +29,4 @@ ice_clip_bool ice_clip_set(const char *text);
 ice_clip_bool ice_clip_clear(void);
 ]])
 
-local lib = ffi_load("ice_clip")
-_setmetatable(_G, { __index = lib })
+return ffi_load("ice_clip")

--- a/bindings/luajit/ice_cpu.lua
+++ b/bindings/luajit/ice_cpu.lua
@@ -1,7 +1,6 @@
 local ffi = require("ffi")
 local ffi_load = ffi.load
 local ffi_cdef = ffi.cdef
-local _setmetatable = setmetatable
 
 ffi_cdef([[
 /* ============================== Data Types ============================== */
@@ -20,9 +19,8 @@ typedef struct ice_cpu_info {
 
 /* ============================== Functions ============================== */
 
-/* Retrives info about CPU and stores info into ice_cpu_info struct by pointing to, Returns ICE_CPU_TRUE on success or ICE_CPU_FALSE on failure */
+/* Retreves info about CPU and stores info into ice_cpu_info struct by pointing to, Returns ICE_CPU_TRUE on success or ICE_CPU_FALSE on failure */
 ice_cpu_bool ice_cpu_get_info(ice_cpu_info *cpu_info);
 ]])
 
-local lib = ffi_load("ice_cpu")
-_setmetatable(_G, { __index = lib })
+return ffi_load("ice_cpu")

--- a/bindings/luajit/ice_ease.lua
+++ b/bindings/luajit/ice_ease.lua
@@ -74,4 +74,4 @@ local lib = _setmetatable({}, mt)
 
 lib.ICE_EASE_PI = 3.14159265358979323846
 
-_setmetatable(_G, { __index = lib })
+return lib

--- a/bindings/luajit/ice_ffi.lua
+++ b/bindings/luajit/ice_ffi.lua
@@ -1,7 +1,6 @@
 local ffi = require("ffi")
 local ffi_load = ffi.load
 local ffi_cdef = ffi.cdef
-local _setmetatable = setmetatable
 
 ffi_cdef([[
 /* ============================== Data Types ============================== */
@@ -27,5 +26,4 @@ ice_ffi_bool ice_ffi_unload(ice_ffi_handle lib);
 ice_ffi_handle ice_ffi_get(ice_ffi_handle lib, const char *symbol);
 ]])
 
-local lib = ffi_load("ice_ffi")
-_setmetatable(_G, { __index = lib })
+return ffi_load("ice_ffi")

--- a/bindings/luajit/ice_ram.lua
+++ b/bindings/luajit/ice_ram.lua
@@ -1,7 +1,6 @@
 local ffi = require("ffi")
 local ffi_load = ffi.load
 local ffi_cdef = ffi.cdef
-local _setmetatable = setmetatable
 
 ffi_cdef([[
 /* ============================== Data Types ============================== */
@@ -20,9 +19,8 @@ typedef struct ice_ram_info { ice_ram_bytes free, used, total; } ice_ram_info;
     
 /* ============================== Functions ============================== */
     
-/* Retrives info about RAM (free, used, total) in bytes and stores info into ice_ram_info struct by pointing to, Returns ICE_RAM_TRUE on success or ICE_RAM_FALSE on failure */
+/* Retrieves info about RAM (free, used, total) in bytes and stores info into ice_ram_info struct by pointing to, Returns ICE_RAM_TRUE on success or ICE_RAM_FALSE on failure */
 ice_ram_bool ice_ram_get_info(ice_ram_info *ram_info);
 ]])
 
-local lib = ffi_load("ice_ram")
-_setmetatable(_G, { __index = lib })
+return ffi_load("ice_ram")

--- a/bindings/luajit/ice_str.lua
+++ b/bindings/luajit/ice_str.lua
@@ -1,7 +1,6 @@
 local ffi = require("ffi")
 local ffi_load = ffi.load
 local ffi_cdef = ffi.cdef
-local _setmetatable = setmetatable
 
 ffi_cdef([[
 /* ============================== Data Types ============================== */
@@ -90,5 +89,4 @@ void ice_str_free_bytes(int *bytes);
 void ice_str_arr_free(char **arr, unsigned long arrlen);
 ]])
 
-local lib = ffi_load("ice_str")
-_setmetatable(_G, { __index = lib })
+return ffi_load("ice_str")

--- a/bindings/luajit/ice_time.lua
+++ b/bindings/luajit/ice_time.lua
@@ -1,7 +1,6 @@
 local ffi = require("ffi")
 local ffi_load = ffi.load
 local ffi_cdef = ffi.cdef
-local _setmetatable = setmetatable
 
 ffi_cdef([[
 /* ============================== Data Types ============================== */
@@ -150,5 +149,4 @@ double ice_time_sec_to_us(ice_time_ulong sec);
 double ice_time_sec_to_ms(ice_time_ulong sec);
 ]])
 
-local lib = ffi_load("ice_time")
-_setmetatable(_G, { __index = lib })
+return ffi_load("ice_time")

--- a/bindings/nelua/examples/hello_ice_al.nelua
+++ b/bindings/nelua/examples/hello_ice_al.nelua
@@ -1,0 +1,48 @@
+require "ice_al"
+require "string"
+
+local function main(): cint
+  local res: ice_al_bool
+  
+  -- OpenAL device and OpenAL device name
+  local device_name: cstring
+  local dev: *ALCdevice
+
+  -- Define the path of the OpenAL shared library/object depending on the platform (NOTE: You can also use OpenAL-soft) */
+## if ccinfo.is_windows then
+  local path: cstring <const> = "OpenAL32.dll"
+## else
+  local path: cstring <const> = "./liboal.so"
+## end
+
+  -- Load OpenAL shared library/object then load OpenAL API
+  res = ice_al_load(path)
+  
+  -- If the function failed to load OpenAL shared library and failed to load OpenAL API, Trace error then terminate the program
+  if (res == ICE_AL_FALSE) then
+    print("ERROR: failed to load OpenAL shared library/object!")
+    return -1
+  end
+  
+  -- Get the default OpenAL audio device and initialize it
+  device_name = alcGetString(nilptr, ALC_DEFAULT_DEVICE_SPECIFIER)
+  dev = alcOpenDevice(device_name)
+  
+  -- If the function failed to initialize the default OpenAL device, Trace error then terminate the program
+  if (dev == 0) then
+    print("ERROR: failed to open audio device!")
+    return -1
+  end
+  
+  print("OpenAL audio device works!")
+  
+  -- Once done close the OpenAL device, If the function failed to close the default OpenAL device, Trace error then terminate the program
+  if (alcCloseDevice(dev) == ALC_FALSE) then
+    print("ERROR: failed to close audio device!")
+    return -1
+  end
+    
+  return 0
+end
+
+return main()

--- a/bindings/nelua/examples/hello_ice_batt.nelua
+++ b/bindings/nelua/examples/hello_ice_batt.nelua
@@ -1,0 +1,25 @@
+require "ice_batt"
+require "string"
+
+local function main(): cint
+  -- Struct that contains information about the battery
+  local batt: ice_batt_info <noinit>
+
+  -- Fetch battery information and store the information in the struct
+  local res: ice_batt_error = ice_batt_get_info(&batt)
+
+  -- If the function failed to fetch battery information, Trace error then terminate the program
+  if (res ~= ICE_BATT_ERROR_OK) then
+    print("ERROR: failed to fetch battery information!")
+    return -1
+  end
+
+  -- Print the informations
+  print("Device has battery: " .. ((batt.exists == ICE_BATT_TRUE) and "YES" or "NO") ..
+        "\nIs battery charging: " .. ((batt.charging == ICE_BATT_TRUE) and "YES" or "NO") ..
+        "\nBattery Level: " .. batt.level)
+
+  return 0
+end
+
+return main()

--- a/bindings/nelua/examples/hello_ice_clip.nelua
+++ b/bindings/nelua/examples/hello_ice_clip.nelua
@@ -1,0 +1,44 @@
+require "ice_clip"
+require "string"
+
+local function main(): cint
+  -- To store result of called functions
+  local res: ice_clip_bool
+  
+  -- String to copy to clipboard later...
+  local str: cstring <const> = "SPEED!"
+  
+  -- Retrieve the clipboard text
+  local text: cstring <const> = ice_clip_get()
+  
+  -- If the function failed to retrieve Clipboard text or Clipboard has no text then trace log a note, Else print the retrieved text...
+  if (text == nil) then
+    print("LOG: failed to retrieve Clipboard text, Maybe the Clipboard does not contain text?")
+  else
+    print("Text from the Clipboard: " .. text)
+  end
+
+  -- Clear the Clipboard
+  res = ice_clip_clear()
+  
+  -- If the function failed to clear the Clipboard, Trace error then terminate the program
+  if (res == ICE_CLIP_FALSE) then
+    print("ERROR: failed to clear the Clipboard!")
+    return -1
+  end
+  
+  -- Copy text to Clipboard
+  res = ice_clip_set(str)
+  
+  -- If the function failed to copy text to the Clipboard, Trace error then terminate the program
+  if (res == ICE_CLIP_FALSE) then
+    print("ERROR: Failed to copy text to Clipboard!")
+    return -1
+  end
+  
+  print("Text copied to the Clipboard: " .. str)
+
+  return 0
+end
+
+return main()

--- a/bindings/nelua/examples/hello_ice_cpu.nelua
+++ b/bindings/nelua/examples/hello_ice_cpu.nelua
@@ -1,0 +1,23 @@
+require "ice_cpu"
+require "string"
+
+local function main(): cint
+  -- Struct that contains CPU information
+  local cpu: ice_cpu_info <noinit>
+
+  -- Get CPU information
+  local res: ice_cpu_bool = ice_cpu_get_info(&cpu)
+  
+  -- If the function failed to retrieve CPU information, Trace error then terminate the program
+  if (res == ICE_CPU_FALSE) then
+    print("ERROR: failed to retrieve CPU information!")
+    return -1
+  end
+
+  -- Print the informations
+  print("CPU Name: " .. cpu.name .. "\nCPU Cores: " .. cpu.cores)
+
+  return 0
+end
+
+return main()

--- a/bindings/nelua/examples/hello_ice_ease.nelua
+++ b/bindings/nelua/examples/hello_ice_ease.nelua
@@ -1,0 +1,20 @@
+require "ice_ease"
+require "string"
+
+local function main(): cint
+  local linear1: float64
+  local linear4: float64
+  
+  -- Use linear easing, With 1 argument (easings.net)
+  linear1 = ice_ease_linear(ICE_EASE_TYPE_PROGRESS, 5.0)
+  
+  -- Use linear easing, But with 4 arguments (Robert Penner's version)
+  linear4 = ice_ease_linear(ICE_EASE_TYPE_PENNER, 1.0, 2.0, 3.0, 4.0)
+  
+  -- Print the results...
+  print("Linear easing with one variable: " .. linear1 .. "\nLinear easing with four variables: " .. linear4)
+
+  return 0
+end
+
+return main()

--- a/bindings/nelua/examples/hello_ice_ffi.nelua
+++ b/bindings/nelua/examples/hello_ice_ffi.nelua
@@ -1,0 +1,54 @@
+require "ice_ffi"
+require "string"
+
+local function main(): cint
+  -- To store result of unloading the shared library/object
+  local unload_res: ice_ffi_bool
+  
+  -- Handle for shared library/object
+  local lib: ice_ffi_handle
+  
+  -- function from shared library/object
+  local F42: function(): cuint
+  
+  -- Define path of the shared library/object depending on platform
+## if ccinfo.is_windows then
+  local path: cstring <const> = "lib42.dll"
+## else
+  local path: cstring <const> = "./lib42.so"
+## end
+
+  -- Load the shared library/object
+  lib = ice_ffi_load(path)
+  
+  -- If the function failed to load the shared library/object, Trace error then terminate the program
+  if (lib == nil) then
+    print("ERROR: failed to load shared library/object!")
+    return -1
+  end
+  
+  -- If the shared library/object loaded successfully, Get the function F42 symbol to call it!
+  F42 = (@function(): cuint)(ice_ffi_get(lib, "F42"))
+  
+  -- If the function failed to get symbol from shared library/object, Trace error then terminate the program
+  if (F42 == nil) then
+    print("ERROR: failed to get symbol from shared library/object!")
+    return -1
+  end
+  
+  -- Call the function and print the result!
+  print("F42 cal result: " .. F42())
+  
+  -- When done, Unload symbols and the shared library/object
+  unload_res = ice_ffi_unload(lib)
+  
+  -- If the function failed to unload shared library/object, Trace error then terminate the program
+  if (unload_res == ICE_FFI_FALSE) then
+    print("ERROR: failed to unload shared library/object!")
+    return -1
+  end
+  
+  return 0
+end
+
+return main()

--- a/bindings/nelua/examples/hello_ice_ram.nelua
+++ b/bindings/nelua/examples/hello_ice_ram.nelua
@@ -1,0 +1,23 @@
+require "ice_ram"
+require "string"
+
+local function main(): cint
+  -- Struct that contains RAM information
+  local ram: ice_ram_info <noinit>
+  
+  -- Fetch RAM info
+  local res: ice_ram_bool = ice_ram_get_info(&ram)
+  
+  -- If function failed to fetch RAM info, Trace error then terminate the program
+  if (res == ICE_RAM_FALSE) then
+    print("ERROR: failed to get RAM info!")
+    return -1
+  end
+  
+  -- Print RAM info (free, used, total) in bytes
+  print("Free RAM: " .. ram.free .. " bytes\nUsed RAM: " .. ram.used .. " bytes\n" .. "Total RAM: " .. ram.total .. " bytes")
+
+  return 0
+end
+
+return main()

--- a/bindings/nelua/examples/hello_ice_str.nelua
+++ b/bindings/nelua/examples/hello_ice_str.nelua
@@ -1,0 +1,20 @@
+require "ice_str"
+
+local function main(): cint
+  -- Create a string repeated for multiple times
+  local haha: cstring = ice_str_dup("HA", 8)  -- HAHAHAHAHAHAHAHA
+
+  -- If the function failed to allocate string, Trace error then terminate the program
+  if (haha == 0) then
+    print("ERROR: failed to allocate string!")
+    return -1
+  end
+
+  -- Print the string, Once we done we deallocate/free the string
+  print(haha)
+  ice_str_free(haha)
+  
+  return 0
+end
+
+return main()

--- a/bindings/nelua/examples/hello_ice_time.nelua
+++ b/bindings/nelua/examples/hello_ice_time.nelua
@@ -1,0 +1,23 @@
+require "ice_time"
+require "string"
+
+local function main(): cint
+  -- Struct that contains Time information
+  local current_time: ice_time_info
+  
+  -- Fetch time information and store it in the struct
+  local res: ice_time_error = ice_time_get_info(&current_time)
+  
+  -- If the function failed to fetch time information, Trace error then terminate the program!
+  if (res ~= ICE_TIME_ERROR_OK) then
+    print("ERROR: failed to get time info!")
+    return -1
+  end
+  
+  -- Print current time!
+  print("Current Time: " .. current_time.str)
+
+  return 0
+end
+
+return main()

--- a/bindings/nelua/ice_batt.nelua
+++ b/bindings/nelua/ice_batt.nelua
@@ -2,30 +2,26 @@
   cdefine "ICE_BATT_IMPL"
   cinclude "ice_batt.h"
   
-  cemit "#if defined(ICE_BATT_MICROSOFT)"
+  if ccinfo.is_windows then
     if not ccinfo.is_msc then
       linklib "kernel32"
     end
-  cemit "#elif defined(ICE_BATT_OSX)"
+  elseif ccinfo.is_macos then
     cflags "-framework Foundation -framework CoreFoundation -framework IOKit"
-  cemit "#elif defined(ICE_BATT_IOS)"
+  elseif ccinfo.is_ios then
     cflags "-framework Foundation -framework UIKit"
-  cemit "#elif defined(ICE_BATT_UNIX)"
-    if ccinfo.is_linux then
-      linklib "c"
-    end
-  cemit "#elif defined(ICE_BATT_BSD)"
+  elseif ccinfo.is_linux or ccinfo.is_bsd then
     linklib "c"
-  cemit "#elif defined(ICE_BATT_BB10)"
+  elseif ccinfo.is_bb10 then
     linklib "bbdevice"
-  cemit "#elif defined(ICE_BATT_SWITCH)"
+  elseif ccinfo.is_switch then
     linklib "nx"
-  cemit "#elif defined(ICE_BATT_PSP)"
+  elseif ccinfo.is_psp then
     linklib "psppower"
     linklib "psppower_driver"
-  cemit "#elif defined(ICE_BATT_PSVITA)"
+  elseif ccinfo.is_psvita then
     linklib "ScePower_stub"
-  cemit "#endif"
+  end
 ]]
 
 -- ============================== Data Types ============================== --
@@ -52,10 +48,10 @@ global ice_batt_error: type <cimport, nodecl, using> = @enum(cint) {
 
 -- ============================== Functions ============================== --
 
-## cemit "#if defined(ICE_BATT_ANDROID)"
+## if ccinfo.is_android then
 -- [ANDROID-ONLY, REQUIRED] Sets native activity to be used by ice_batt on Android, This Should be called first before other ice_batt.h functions
 global function ice_batt_use_native_activity(activity: pointer): void <cimport, nodecl> end
-## cemit "#endif"
+## end
 
 -- Fetches battery info and stores info into ice_batt_info struct by pointing to, Returns ICE_BATT_ERROR_OK on success or any other values from ice_batt_error enum on failure!
 global function ice_batt_get_info(batt_info: *ice_batt_info): ice_batt_error <cimport, nodecl> end

--- a/bindings/nelua/ice_clip.nelua
+++ b/bindings/nelua/ice_clip.nelua
@@ -2,24 +2,24 @@
   cdefine "ICE_CLIP_IMPL"
   cinclude "ice_clip.h"
   
-  cemit "#if defined(ICE_CLIP_MICROSOFT)"
+  if ccinfo.is_windows then
     if not ccinfo.is_msc then
       linklib "kernel32"
       linklib "user32"
     end
-  cemit "#elif defined(ICE_CLIP_IOS)"
+  elseif ccinfo.is_ios then
     cflags "-framework Foundation -framework UIKit"
-  cemit "#elif defined(ICE_CLIP_OSX)"
+  elseif ccinfo.is_macos then
     cflags "-framework Foundation -framework AppKit"
-  cemit "#elif defined(ICE_CLIP_BB10)"
+  elseif ccinfo.is_bb10 then
     linklib "bbsystem"
-  cemit "#endif"
+  end
 ]]
 
 -- ============================== Data Types ============================== --
 
 -- Boolean Enum, To avoid including stdbool.h
-global ice_clip_bool: type <cimport, nodecl, using> = @record(cint) {
+global ice_clip_bool: type <cimport, nodecl, using> = @enum(cint) {
   ICE_CLIP_FALSE = -1,
   ICE_CLIP_TRUE  = 0
 }

--- a/bindings/nelua/ice_cpu.nelua
+++ b/bindings/nelua/ice_cpu.nelua
@@ -2,11 +2,11 @@
   cdefine "ICE_CPU_IMPL"
   cinclude "ice_cpu.h"
 
-  cemit "#if (defined(ICE_CPU_MICROSOFT) && !defined(_MSC_VER))
+  if ccinfo.is_windows and not ccinfo.is_msc then
     linklib "kernel32"
-  cemit "#elif (defined(ICE_CPU_UNIX) || defined(ICE_CPU_BSD) || defined(ICE_CPU_BLACKBERRY))"
+  elseif ccinfo.is_bsd or ccinfo.is_linux or ccinfo.is_qnx then
     linklib "c"
-  cemit "#endif"
+  end
 ]]
 
 -- ============================== Data Types ============================== --
@@ -25,5 +25,5 @@ global ice_cpu_info: type <cimport, nodecl> = @record {
 
 -- ============================== Functions ============================== --
 
--- Retrives info about CPU and stores info into ice_cpu_info struct by pointing to, Returns ICE_CPU_TRUE on success or ICE_CPU_FALSE on failure
+-- Retrieves info about CPU and stores info into ice_cpu_info struct by pointing to, Returns ICE_CPU_TRUE on success or ICE_CPU_FALSE on failure
 global function ice_cpu_get_info(cpu_info: *ice_cpu_info): ice_cpu_bool <cimport, nodecl> end

--- a/bindings/nelua/ice_ram.nelua
+++ b/bindings/nelua/ice_ram.nelua
@@ -29,5 +29,5 @@ global ice_ram_info: type <cimport, nodecl> = @record {
 
 -- ============================== Functions ============================== --
 
--- Retrives info about RAM (free, used, total) in bytes and stores info into ice_ram_info struct by pointing to, Returns ICE_RAM_TRUE on success or ICE_RAM_FALSE on failure
+-- Retrieves info about RAM (free, used, total) in bytes and stores info into ice_ram_info struct by pointing to, Returns ICE_RAM_TRUE on success or ICE_RAM_FALSE on failure
 global function ice_ram_get_info(ram_info: *ice_ram_info): ice_ram_bool <cimport, nodecl> end

--- a/bindings/nelua/ice_str.nelua
+++ b/bindings/nelua/ice_str.nelua
@@ -87,7 +87,7 @@ global function ice_str_from_bytes(chars: *[0]cint <const>, arrlen: culong): cst
 global function ice_str_free(str: cstring): void <cimport, nodecl> end
 
 -- Frees array of char codes
-global function ice_str_free(bytes: *[0]cint): void <cimport, nodecl> end
+global function ice_str_free(bytes: cstring): void <cimport, nodecl> end
 
 -- Frees array of strings, arrlen should be set to array length
 global function ice_str_arr_free(arr: *[0]cstring, arrlen: culong): void <cimport, nodecl> end

--- a/bindings/nelua/ice_time.nelua
+++ b/bindings/nelua/ice_time.nelua
@@ -2,24 +2,20 @@
   cdefine "ICE_TIME_IMPL"
   cinclude "ice_time.h"
   
-  cemit "#if defined(ICE_TIME_MICROSOFT)"
-    if not ccinfo.is_msc then
-      cemit "#if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP)"
-        linklib "WindowsPhoneCore"
-      cemit "#else"
-        linklib "kernel32"
-      cemit "#endif"
-    end
-  cemit "#elif (defined(ICE_TIME_UNIX) || defined(ICE_TIME_BSD) || defined(ICE_TIME_BLACKBERRY))"
+  if ccinfo.is_winphone then
+    linklib "WindowsPhoneCore"
+  elseif ccinfo.is_windows then
+    linklib "kernel32"
+  elseif ccinfo.is_linux or ccinfo.is_linux or ccinfo.is_bsd or ccinfo.is_blackberry then
     linklib "c"
-  cemit "#elif defined(ICE_TIME_3DS)"
+  elseif ccinfo.is_3ds then
     linklib "ctru"
-  cemit "#elif defined(ICE_TIME_RPI_PICO)"
+  elseif ccinfo.is_rpi2040 then
     linklib "pico_time"
     linklib "lpico_util"
     linklib "hardware_timer"
     linklib "hardware_rtc"
-  cemit "#endif"
+  end
 ]]
 
 -- ============================== Data Types ============================== --

--- a/rebase/ice_al.h
+++ b/rebase/ice_al.h
@@ -1,4 +1,5 @@
 /*
+
 ice_al.h, Single-Header Cross-Platform C library for working with OpenAL!
 
 
@@ -22,12 +23,12 @@ Check out "Linking Flags" to know which libs required to link for compilation de
 // Helper
 #define trace(fname, str) printf("[%s : line %d] %s() => %s\n", __FILE__, __LINE__, fname, str);
 
-int main(int argc, char** argv) {
+int main(void) {
     ice_al_bool res;
 
     // OpenAL device and OpenAL device name
-    char* device_name;
-    ALCdevice* dev;
+    char *device_name;
+    ALCdevice *dev;
 
     // Define the path of the OpenAL shared library/object depending on the platform (NOTE: You can also use OpenAL-soft)
 #if defined(ICE_AL_MICROSOFT)
@@ -45,7 +46,7 @@ int main(int argc, char** argv) {
         return -1;
     }
     
-    // Get the default OpenAL audio device and initialize
+    // Get the default OpenAL audio device and initialize it
     device_name = alcGetString(NULL, ALC_DEFAULT_DEVICE_SPECIFIER);
     dev = alcOpenDevice(device_name);
     
@@ -273,7 +274,7 @@ extern "C" {
 
 /* [INTERNAL] Macro to ease loading symbols */
 #define ICE_AL_LOAD_PROC(sym)                       \
-    sym = (PFN_##sym) ice_al_proc(#sym);            \
+    *(PFN_##sym**)(&sym) = ice_al_proc(#sym);       \
 
 /* [INTERNAL] Macro to ease unloading symbols */
 #define ICE_AL_UNLOAD_PROC(sym) sym = 0;
@@ -410,99 +411,99 @@ typedef void ALCvoid;
 
 /* ============================= Functions (OpenAL API) ============================= */
 
-ice_al_def_func(void, alDopplerFactor, (ALfloat value));
-ice_al_def_func(void, alSpeedOfSound, (ALfloat value));
-ice_al_def_func(void, alDistanceModel, (ALenum distanceModel));
-ice_al_def_func(void, alEnable, (ALenum capability));
-ice_al_def_func(void, alDisable, (ALenum capability));
-ice_al_def_func(ALboolean, alIsEnabled, (ALenum capability));
-ice_al_def_func(const ALchar *, alGetString, (ALenum param));
-ice_al_def_func(void, alGetBooleanv, (ALenum param, ALboolean *values));
-ice_al_def_func(void, alGetIntegerv, (ALenum param, ALint *values));
-ice_al_def_func(void, alGetFloatv, (ALenum param, ALfloat *values));
-ice_al_def_func(void, alGetDoublev, (ALenum param, ALdouble *values));
-ice_al_def_func(ALboolean, alGetBoolean, (ALenum param));
-ice_al_def_func(ALint, alGetInteger, (ALenum param));
-ice_al_def_func(ALfloat, alGetFloat, (ALenum param));
-ice_al_def_func(ALdouble, alGetDouble, (ALenum param));
-ice_al_def_func(ALenum, alGetError, (void));
-ice_al_def_func(ALboolean, alIsExtensionPresent, (const ALchar *extname));
-ice_al_def_func(void*, alGetProcAddress, (const ALchar *fname));
-ice_al_def_func(ALenum, alGetEnumValue, (const ALchar *ename));
-ice_al_def_func(void, alListenerf, (ALenum param, ALfloat value));
-ice_al_def_func(void, alListener3f, (ALenum param, ALfloat value1, ALfloat value2, ALfloat value3));
-ice_al_def_func(void, alListenerfv, (ALenum param, const ALfloat *values));
-ice_al_def_func(void, alListeneri, (ALenum param, ALint value));
-ice_al_def_func(void, alListener3i, (ALenum param, ALint value1, ALint value2, ALint value3));
-ice_al_def_func(void, alListeneriv, (ALenum param, const ALint *values));
-ice_al_def_func(void, alGetListenerf, (ALenum param, ALfloat *value));
-ice_al_def_func(void, alGetListener3f, (ALenum param, ALfloat *value1, ALfloat *value2, ALfloat *value3));
-ice_al_def_func(void, alGetListenerfv, (ALenum param, ALfloat *values));
-ice_al_def_func(void, alGetListeneri, (ALenum param, ALint *value));
-ice_al_def_func(void, alGetListener3i, (ALenum param, ALint *value1, ALint *value2, ALint *value3));
-ice_al_def_func(void, alGetListeneriv, (ALenum param, ALint *values));
-ice_al_def_func(void, alGenSources, (ALsizei n, ALuint *sources));
-ice_al_def_func(void, alDeleteSources, (ALsizei n, const ALuint *sources));
-ice_al_def_func(ALboolean, alIsSource, (ALuint source));
-ice_al_def_func(void, alSourcef, (ALuint source, ALenum param, ALfloat value));
-ice_al_def_func(void, alSource3f, (ALuint source, ALenum param, ALfloat value1, ALfloat value2, ALfloat value3));
-ice_al_def_func(void, alSourcefv, (ALuint source, ALenum param, const ALfloat *values));
-ice_al_def_func(void, alSourcei, (ALuint source, ALenum param, ALint value));
-ice_al_def_func(void, alSource3i, (ALuint source, ALenum param, ALint value1, ALint value2, ALint value3));
-ice_al_def_func(void, alSourceiv, (ALuint source, ALenum param, const ALint *values));
-ice_al_def_func(void, alGetSourcef, (ALuint source, ALenum param, ALfloat *value));
-ice_al_def_func(void, alGetSource3f, (ALuint source, ALenum param, ALfloat *value1, ALfloat *value2, ALfloat *value3));
-ice_al_def_func(void, alGetSourcefv, (ALuint source, ALenum param, ALfloat *values));
-ice_al_def_func(void, alGetSourcei, (ALuint source,  ALenum param, ALint *value));
-ice_al_def_func(void, alGetSource3i, (ALuint source, ALenum param, ALint *value1, ALint *value2, ALint *value3));
-ice_al_def_func(void, alGetSourceiv, (ALuint source,  ALenum param, ALint *values));
-ice_al_def_func(void, alSourcePlayv, (ALsizei n, const ALuint *sources));
-ice_al_def_func(void, alSourceStopv, (ALsizei n, const ALuint *sources));
-ice_al_def_func(void, alSourceRewindv, (ALsizei n, const ALuint *sources));
-ice_al_def_func(void, alSourcePausev, (ALsizei n, const ALuint *sources));
-ice_al_def_func(void, alSourcePlay, (ALuint source));
-ice_al_def_func(void, alSourceStop, (ALuint source));
-ice_al_def_func(void, alSourceRewind, (ALuint source));
-ice_al_def_func(void, alSourcePause, (ALuint source));
-ice_al_def_func(void, alSourceQueueBuffers, (ALuint source, ALsizei nb, const ALuint *buffers));
-ice_al_def_func(void, alSourceUnqueueBuffers, (ALuint source, ALsizei nb, ALuint *buffers));
-ice_al_def_func(void, alGenBuffers, (ALsizei n, ALuint *buffers));
-ice_al_def_func(void, alDeleteBuffers, (ALsizei n, const ALuint *buffers));
-ice_al_def_func(ALboolean, alIsBuffer, (ALuint buffer));
-ice_al_def_func(void, alBufferData, (ALuint buffer, ALenum format, const ALvoid *data, ALsizei size, ALsizei freq));
-ice_al_def_func(void, alBufferf, (ALuint buffer, ALenum param, ALfloat value));
-ice_al_def_func(void, alBuffer3f, (ALuint buffer, ALenum param, ALfloat value1, ALfloat value2, ALfloat value3));
-ice_al_def_func(void, alBufferfv, (ALuint buffer, ALenum param, const ALfloat *values));
-ice_al_def_func(void, alBufferi, (ALuint buffer, ALenum param, ALint value));
-ice_al_def_func(void, alBuffer3i, (ALuint buffer, ALenum param, ALint value1, ALint value2, ALint value3));
-ice_al_def_func(void, alBufferiv, (ALuint buffer, ALenum param, const ALint *values));
-ice_al_def_func(void, alGetBufferf, (ALuint buffer, ALenum param, ALfloat *value));
-ice_al_def_func(void, alGetBuffer3f, (ALuint buffer, ALenum param, ALfloat *value1, ALfloat *value2, ALfloat *value3));
-ice_al_def_func(void, alGetBufferfv, (ALuint buffer, ALenum param, ALfloat *values));
-ice_al_def_func(void, alGetBufferi, (ALuint buffer, ALenum param, ALint *value));
-ice_al_def_func(void, alGetBuffer3i, (ALuint buffer, ALenum param, ALint *value1, ALint *value2, ALint *value3));
-ice_al_def_func(void, alGetBufferiv, (ALuint buffer, ALenum param, ALint *values));
+ice_al_def_func(void, alDopplerFactor, (ALfloat value))
+ice_al_def_func(void, alSpeedOfSound, (ALfloat value))
+ice_al_def_func(void, alDistanceModel, (ALenum distanceModel))
+ice_al_def_func(void, alEnable, (ALenum capability))
+ice_al_def_func(void, alDisable, (ALenum capability))
+ice_al_def_func(ALboolean, alIsEnabled, (ALenum capability))
+ice_al_def_func(const ALchar *, alGetString, (ALenum param))
+ice_al_def_func(void, alGetBooleanv, (ALenum param, ALboolean *values))
+ice_al_def_func(void, alGetIntegerv, (ALenum param, ALint *values))
+ice_al_def_func(void, alGetFloatv, (ALenum param, ALfloat *values))
+ice_al_def_func(void, alGetDoublev, (ALenum param, ALdouble *values))
+ice_al_def_func(ALboolean, alGetBoolean, (ALenum param))
+ice_al_def_func(ALint, alGetInteger, (ALenum param))
+ice_al_def_func(ALfloat, alGetFloat, (ALenum param))
+ice_al_def_func(ALdouble, alGetDouble, (ALenum param))
+ice_al_def_func(ALenum, alGetError, (void))
+ice_al_def_func(ALboolean, alIsExtensionPresent, (const ALchar *extname))
+ice_al_def_func(void*, alGetProcAddress, (const ALchar *fname))
+ice_al_def_func(ALenum, alGetEnumValue, (const ALchar *ename))
+ice_al_def_func(void, alListenerf, (ALenum param, ALfloat value))
+ice_al_def_func(void, alListener3f, (ALenum param, ALfloat value1, ALfloat value2, ALfloat value3))
+ice_al_def_func(void, alListenerfv, (ALenum param, const ALfloat *values))
+ice_al_def_func(void, alListeneri, (ALenum param, ALint value))
+ice_al_def_func(void, alListener3i, (ALenum param, ALint value1, ALint value2, ALint value3))
+ice_al_def_func(void, alListeneriv, (ALenum param, const ALint *values))
+ice_al_def_func(void, alGetListenerf, (ALenum param, ALfloat *value))
+ice_al_def_func(void, alGetListener3f, (ALenum param, ALfloat *value1, ALfloat *value2, ALfloat *value3))
+ice_al_def_func(void, alGetListenerfv, (ALenum param, ALfloat *values))
+ice_al_def_func(void, alGetListeneri, (ALenum param, ALint *value))
+ice_al_def_func(void, alGetListener3i, (ALenum param, ALint *value1, ALint *value2, ALint *value3))
+ice_al_def_func(void, alGetListeneriv, (ALenum param, ALint *values))
+ice_al_def_func(void, alGenSources, (ALsizei n, ALuint *sources))
+ice_al_def_func(void, alDeleteSources, (ALsizei n, const ALuint *sources))
+ice_al_def_func(ALboolean, alIsSource, (ALuint source))
+ice_al_def_func(void, alSourcef, (ALuint source, ALenum param, ALfloat value))
+ice_al_def_func(void, alSource3f, (ALuint source, ALenum param, ALfloat value1, ALfloat value2, ALfloat value3))
+ice_al_def_func(void, alSourcefv, (ALuint source, ALenum param, const ALfloat *values))
+ice_al_def_func(void, alSourcei, (ALuint source, ALenum param, ALint value))
+ice_al_def_func(void, alSource3i, (ALuint source, ALenum param, ALint value1, ALint value2, ALint value3))
+ice_al_def_func(void, alSourceiv, (ALuint source, ALenum param, const ALint *values))
+ice_al_def_func(void, alGetSourcef, (ALuint source, ALenum param, ALfloat *value))
+ice_al_def_func(void, alGetSource3f, (ALuint source, ALenum param, ALfloat *value1, ALfloat *value2, ALfloat *value3))
+ice_al_def_func(void, alGetSourcefv, (ALuint source, ALenum param, ALfloat *values))
+ice_al_def_func(void, alGetSourcei, (ALuint source,  ALenum param, ALint *value))
+ice_al_def_func(void, alGetSource3i, (ALuint source, ALenum param, ALint *value1, ALint *value2, ALint *value3))
+ice_al_def_func(void, alGetSourceiv, (ALuint source,  ALenum param, ALint *values))
+ice_al_def_func(void, alSourcePlayv, (ALsizei n, const ALuint *sources))
+ice_al_def_func(void, alSourceStopv, (ALsizei n, const ALuint *sources))
+ice_al_def_func(void, alSourceRewindv, (ALsizei n, const ALuint *sources))
+ice_al_def_func(void, alSourcePausev, (ALsizei n, const ALuint *sources))
+ice_al_def_func(void, alSourcePlay, (ALuint source))
+ice_al_def_func(void, alSourceStop, (ALuint source))
+ice_al_def_func(void, alSourceRewind, (ALuint source))
+ice_al_def_func(void, alSourcePause, (ALuint source))
+ice_al_def_func(void, alSourceQueueBuffers, (ALuint source, ALsizei nb, const ALuint *buffers))
+ice_al_def_func(void, alSourceUnqueueBuffers, (ALuint source, ALsizei nb, ALuint *buffers))
+ice_al_def_func(void, alGenBuffers, (ALsizei n, ALuint *buffers))
+ice_al_def_func(void, alDeleteBuffers, (ALsizei n, const ALuint *buffers))
+ice_al_def_func(ALboolean, alIsBuffer, (ALuint buffer))
+ice_al_def_func(void, alBufferData, (ALuint buffer, ALenum format, const ALvoid *data, ALsizei size, ALsizei freq))
+ice_al_def_func(void, alBufferf, (ALuint buffer, ALenum param, ALfloat value))
+ice_al_def_func(void, alBuffer3f, (ALuint buffer, ALenum param, ALfloat value1, ALfloat value2, ALfloat value3))
+ice_al_def_func(void, alBufferfv, (ALuint buffer, ALenum param, const ALfloat *values))
+ice_al_def_func(void, alBufferi, (ALuint buffer, ALenum param, ALint value))
+ice_al_def_func(void, alBuffer3i, (ALuint buffer, ALenum param, ALint value1, ALint value2, ALint value3))
+ice_al_def_func(void, alBufferiv, (ALuint buffer, ALenum param, const ALint *values))
+ice_al_def_func(void, alGetBufferf, (ALuint buffer, ALenum param, ALfloat *value))
+ice_al_def_func(void, alGetBuffer3f, (ALuint buffer, ALenum param, ALfloat *value1, ALfloat *value2, ALfloat *value3))
+ice_al_def_func(void, alGetBufferfv, (ALuint buffer, ALenum param, ALfloat *values))
+ice_al_def_func(void, alGetBufferi, (ALuint buffer, ALenum param, ALint *value))
+ice_al_def_func(void, alGetBuffer3i, (ALuint buffer, ALenum param, ALint *value1, ALint *value2, ALint *value3))
+ice_al_def_func(void, alGetBufferiv, (ALuint buffer, ALenum param, ALint *values))
 
-ice_al_def_func(ALCcontext*, alcCreateContext, (ALCdevice *device, const ALCint *attrlist));
-ice_al_def_func(ALCboolean, alcMakeContextCurrent, (ALCcontext *context));
-ice_al_def_func(void, alcProcessContext, (ALCcontext *context));
-ice_al_def_func(void, alcSuspendContext, (ALCcontext *context));
-ice_al_def_func(void, alcDestroyContext, (ALCcontext *context));
-ice_al_def_func(ALCcontext*, alcGetCurrentContext, (void));
-ice_al_def_func(ALCdevice*, alcGetContextsDevice, (ALCcontext *context));
-ice_al_def_func(ALCdevice*, alcOpenDevice, (const ALCchar *devicename));
-ice_al_def_func(ALCboolean, alcCloseDevice, (ALCdevice *device));
-ice_al_def_func(ALCenum, alcGetError, (ALCdevice *device));
-ice_al_def_func(ALCboolean, alcIsExtensionPresent, (ALCdevice *device, const ALCchar *extname));
-ice_al_def_func(ALCvoid*, alcGetProcAddress, (ALCdevice *device, const ALCchar *funcname));
-ice_al_def_func(ALCenum, alcGetEnumValue, (ALCdevice *device, const ALCchar *enumname));
-ice_al_def_func(ALCchar*, alcGetString, (ALCdevice *device, ALCenum param));
-ice_al_def_func(void, alcGetIntegerv, (ALCdevice *device, ALCenum param, ALCsizei size, ALCint *values));
-ice_al_def_func(ALCdevice*, alcCaptureOpenDevice, (const ALCchar *devicename, ALCuint frequency, ALCenum format, ALCsizei buffersize));
-ice_al_def_func(ALCboolean, alcCaptureCloseDevice, (ALCdevice *device));
-ice_al_def_func(void, alcCaptureStart, (ALCdevice *device));
-ice_al_def_func(void, alcCaptureStop, (ALCdevice *device));
-ice_al_def_func(void, alcCaptureSamples, (ALCdevice *device, ALCvoid* buffer, ALCsizei samples));
+ice_al_def_func(ALCcontext*, alcCreateContext, (ALCdevice *device, const ALCint *attrlist))
+ice_al_def_func(ALCboolean, alcMakeContextCurrent, (ALCcontext *context))
+ice_al_def_func(void, alcProcessContext, (ALCcontext *context))
+ice_al_def_func(void, alcSuspendContext, (ALCcontext *context))
+ice_al_def_func(void, alcDestroyContext, (ALCcontext *context))
+ice_al_def_func(ALCcontext*, alcGetCurrentContext, (void))
+ice_al_def_func(ALCdevice*, alcGetContextsDevice, (ALCcontext *context))
+ice_al_def_func(ALCdevice*, alcOpenDevice, (const ALCchar *devicename))
+ice_al_def_func(ALCboolean, alcCloseDevice, (ALCdevice *device))
+ice_al_def_func(ALCenum, alcGetError, (ALCdevice *device))
+ice_al_def_func(ALCboolean, alcIsExtensionPresent, (ALCdevice *device, const ALCchar *extname))
+ice_al_def_func(ALCvoid*, alcGetProcAddress, (ALCdevice *device, const ALCchar *funcname))
+ice_al_def_func(ALCenum, alcGetEnumValue, (ALCdevice *device, const ALCchar *enumname))
+ice_al_def_func(ALCchar*, alcGetString, (ALCdevice *device, ALCenum param))
+ice_al_def_func(void, alcGetIntegerv, (ALCdevice *device, ALCenum param, ALCsizei size, ALCint *values))
+ice_al_def_func(ALCdevice*, alcCaptureOpenDevice, (const ALCchar *devicename, ALCuint frequency, ALCenum format, ALCsizei buffersize))
+ice_al_def_func(ALCboolean, alcCaptureCloseDevice, (ALCdevice *device))
+ice_al_def_func(void, alcCaptureStart, (ALCdevice *device))
+ice_al_def_func(void, alcCaptureStop, (ALCdevice *device))
+ice_al_def_func(void, alcCaptureSamples, (ALCdevice *device, ALCvoid* buffer, ALCsizei samples))
 
 /* ============================= Data Types ============================= */
 
@@ -570,7 +571,7 @@ ICE_AL_API ice_al_handle ICE_AL_CALLCONV ice_al_proc(const char *symbol) {
 }
 
 /* Loads OpenAL API from shared library path (ex. openal32.dll on Windows), Returns ICE_AL_TRUE on success or ICE_AL_FALSE on failure */
-ICE_AL_API ice_al_bool ICE_AL_CALLCONV ice_al_load(const char* path) {
+ICE_AL_API ice_al_bool ICE_AL_CALLCONV ice_al_load(const char *path) {
 #if defined(ICE_AL_MICROSOFT)
     ice_al_lib = LoadLibraryA(path);
     if (ice_al_lib == 0) return ICE_AL_FALSE;
@@ -781,7 +782,7 @@ ICE_AL_API ice_al_bool ICE_AL_CALLCONV ice_al_unload(void) {
     ICE_AL_UNLOAD_PROC(alcCaptureSamples);
 
 #if defined(ICE_AL_MICROSOFT)
-    res = (FreeLibrary(lib) != 0) ? 0 : -1;
+    res = (FreeLibrary(ice_al_lib) != 0) ? 0 : -1;
 
 #elif defined(ICE_AL_BEOS)
     res = unload_add_on((isize) ice_al_lib);

--- a/rebase/ice_batt.h
+++ b/rebase/ice_batt.h
@@ -1,4 +1,5 @@
 /*
+
 ice_batt.h, Single-Header Cross-Platform C library to get battery info!
 
 
@@ -22,8 +23,8 @@ Check out "Linking Flags" to know which libs required to link for compilation de
 // Helper
 #define trace(fname, str) printf("[%s : line %d] %s() => %s\n", __FILE__, __LINE__, fname, str);
 
-int main(int argc, char **argv) {
-    // Struct that contains battery information
+int main(void) {
+    // Struct that contains information about the battery
     ice_batt_info batt;
 
     // Fetch battery information and store the information in the struct
@@ -35,7 +36,7 @@ int main(int argc, char **argv) {
         return -1;
     }
 
-    // Print information we got
+    // Print the informations
     printf("Device has battery: %s\nIs battery charging: %s\nBattery Level: %u\n",
       (batt.exists == ICE_BATT_TRUE) ? "YES" : "NO",
       (batt.charging == ICE_BATT_TRUE) ? "YES" : "NO",
@@ -373,12 +374,11 @@ typedef enum bool { false, true } bool;
 #elif defined(ICE_BATT_BB10)
 #  include <bb/device/BatteryInfo>
 #  include <bb/device/BatteryChargingState>
-using namespace bb::device;
 #elif defined(ICE_BATT_WEB)
 #  include <emscripten/html5.h>
 #elif defined(ICE_BATT_UWP)
-using namespace Windows::Devices::Power;
-using namespace Windows::System::Power;
+#  include <windows.devices.power.h>
+#  include <windows.system.power.h>
 #elif defined(ICE_BATT_MICROSOFT)
 #  if defined(_MSC_VER)
 #    include <windows.h>
@@ -436,7 +436,7 @@ ICE_BATT_API void ICE_BATT_CALLCONV ice_batt_use_native_activity(void *activity)
 #endif
 
 /* Fetches battery info and stores info into ice_batt_info struct by pointing to, Returns ICE_BATT_ERROR_OK on success or any other values from ice_batt_error enum on failure! */
-ICE_BATT_API ice_batt_error ICE_BATT_CALLCONV ice_batt_get_status(ice_batt_info *batt_info) {
+ICE_BATT_API ice_batt_error ICE_BATT_CALLCONV ice_batt_get_info(ice_batt_info *batt_info) {
     ice_batt_error error = ICE_BATT_ERROR_OK;
 #if defined(ICE_BATT_ANDROID)
     JNIEnv *env = ice_batt_native_activity->env;

--- a/rebase/ice_ease.h
+++ b/rebase/ice_ease.h
@@ -1,4 +1,5 @@
 /*
+
 ice_ease.h, Single-Header Cross-Platform C library for working with Easings!
 
 
@@ -19,7 +20,7 @@ Check out "Linking Flags" to know which libs required to link for compilation de
 
 #include <stdio.h>
 
-int main(int argc, char **argv) {
+int main(void) {
     double linear1, linear4;
 
     // Use linear easing, With 1 argument (easings.net)
@@ -356,10 +357,6 @@ ICE_EASE_API double ICE_EASE_CALLCONV ice_ease_bounce_in_out(ice_ease_type ease_
 #include <stdarg.h>
 #include <math.h>
 
-#if defined(ICE_EASE_MICROSOFT) && defined(_MSC_VER)
-#  pragma comment(lib, "msvcrt.lib")
-#endif
-
 /* [INTERNAL] Assigns variable arguments to array */
 #define ICE_EASE_ASSIGN_ARGS            \
     double args[4];                     \
@@ -411,7 +408,9 @@ ICE_EASE_API double ICE_EASE_CALLCONV ice_ease_quad_in(ice_ease_type ease_type, 
 
     } else if (ease_type == ICE_EASE_TYPE_PENNER) {
         ICE_EASE_LOAD_FOUR_ARGS
-        return c * (t /= d) * t + b;
+        t /= d;
+
+        return c * t * t + b;
     }
 
     return 0;
@@ -426,7 +425,9 @@ ICE_EASE_API double ICE_EASE_CALLCONV ice_ease_quad_out(ice_ease_type ease_type,
 
     } else if (ease_type == ICE_EASE_TYPE_PENNER) {
         ICE_EASE_LOAD_FOUR_ARGS
-        return -c * (t /= d) * (t - 2.0) + b;
+        t /= d;
+
+        return -c * t * (t - 2.0) + b;
     }
 
     return 0;
@@ -441,9 +442,12 @@ ICE_EASE_API double ICE_EASE_CALLCONV ice_ease_quad_in_out(ice_ease_type ease_ty
 
     } else if (ease_type == ICE_EASE_TYPE_PENNER) {
         ICE_EASE_LOAD_FOUR_ARGS
+        t /= d / 2.0;
 
-        if ((t /= d / 2.0) < 1.0) return c / 2.0 * t * t + b;
-        return -c / 2.0 * ((--t) * (t - 2.0) - 1.0) + b;
+        if (t < 1.0) return c / 2.0 * t * t + b;
+        
+        --t;
+        return -c / 2.0 * (t * (t - 2.0) - 1.0) + b;
     }
 
     return 0;
@@ -459,7 +463,9 @@ ICE_EASE_API double ICE_EASE_CALLCONV ice_ease_cubic_in(ice_ease_type ease_type,
 
     } else if (ease_type == ICE_EASE_TYPE_PENNER) {
         ICE_EASE_LOAD_FOUR_ARGS
-        return c * (t /= d) * t * t + b;
+        t /= d;
+
+        return c * t * t * t + b;
     }
 
     return 0;
@@ -474,7 +480,9 @@ ICE_EASE_API double ICE_EASE_CALLCONV ice_ease_cubic_out(ice_ease_type ease_type
 
     } else if (ease_type == ICE_EASE_TYPE_PENNER) {
         ICE_EASE_LOAD_FOUR_ARGS
-        return c * ((t = t / d - 1.0) * t * t + 1.0) + b;
+        t = t / d - 1.0;
+
+        return c * (t * t * t + 1.0) + b;
     }
 
     return 0;
@@ -490,8 +498,12 @@ ICE_EASE_API double ICE_EASE_CALLCONV ice_ease_cubic_in_out(ice_ease_type ease_t
 
     } else if (ease_type == ICE_EASE_TYPE_PENNER) {
         ICE_EASE_LOAD_FOUR_ARGS
-        if ((t /= d / 2.0) < 1.0) return c / 2.0 * t * t * t + b;
-        return c / 2.0 * ((t -= 2.0) * t * t + 2.0) + b;
+        t /= d / 2.0;
+
+        if (t < 1.0) return c / 2.0 * t * t * t + b;
+        
+        t -= 2.0;
+        return c / 2.0 * (t * t * t + 2.0) + b;
     }
 
     return 0;
@@ -507,7 +519,9 @@ ICE_EASE_API double ICE_EASE_CALLCONV ice_ease_quart_in(ice_ease_type ease_type,
 
     } else if (ease_type == ICE_EASE_TYPE_PENNER) {
         ICE_EASE_LOAD_FOUR_ARGS
-        return c * (t /= d) * t * t * t + b;
+        t /= d;
+
+        return c * t * t * t * t + b;
     }
 
     return 0;
@@ -522,7 +536,9 @@ ICE_EASE_API double ICE_EASE_CALLCONV ice_ease_quart_out(ice_ease_type ease_type
 
     } else if (ease_type == ICE_EASE_TYPE_PENNER) {
         ICE_EASE_LOAD_FOUR_ARGS
-        return -c * ((t = t / d - 1.0) * t * t * t - 1.0) + b;
+        t = t / d - 1.0;
+
+        return -c * (t * t * t * t - 1.0) + b;
     }
 
     return 0;
@@ -538,9 +554,12 @@ ICE_EASE_API double ICE_EASE_CALLCONV ice_ease_quart_in_out(ice_ease_type ease_t
 
     } else if (ease_type == ICE_EASE_TYPE_PENNER) {
         ICE_EASE_LOAD_FOUR_ARGS
+        t /= d / 2.0;
 
-        if ((t /= d / 2.0) < 1.0) return c / 2.0 * t * t * t * t + b;
-        return -c / 2.0 * ((t -= 2.0) * t * t * t - 2.0) + b;
+        if (t < 1.0) return c / 2.0 * t * t * t * t + b;
+        
+        t -= 2.0;
+        return -c / 2.0 * (t * t * t * t - 2.0) + b;
     }
 
     return 0;
@@ -556,7 +575,9 @@ ICE_EASE_API double ICE_EASE_CALLCONV ice_ease_quint_in(ice_ease_type ease_type,
 
     } else if (ease_type == ICE_EASE_TYPE_PENNER) {
         ICE_EASE_LOAD_FOUR_ARGS
-        return c * (t /= d) * t * t * t * t + b;
+        t /= d;
+
+        return c * t * t * t * t * t + b;
     }
 
     return 0;
@@ -571,7 +592,9 @@ ICE_EASE_API double ICE_EASE_CALLCONV ice_ease_quint_out(ice_ease_type ease_type
 
     } else if (ease_type == ICE_EASE_TYPE_PENNER) {
         ICE_EASE_LOAD_FOUR_ARGS
-        return c * ((t = t / d - 1.0) * t * t * t * t + 1.0) + b;
+        t = t / d - 1.0;
+
+        return c * (t * t * t * t * t + 1.0) + b;
     }
 
     return 0;
@@ -587,8 +610,12 @@ ICE_EASE_API double ICE_EASE_CALLCONV ice_ease_quint_in_out(ice_ease_type ease_t
 
     } else if (ease_type == ICE_EASE_TYPE_PENNER) {
         ICE_EASE_LOAD_FOUR_ARGS
-        if ((t /= d / 2.0) < 1.0) return c / 2.0 * t * t * t * t * t + b;
-        return c / 2.0 * ((t -= 2.0) * t * t * t * t + 2.0) + b;
+        t /= d / 2.0;
+
+        if (t < 1.0) return c / 2.0 * t * t * t * t * t + b;
+        t -= 2.0;
+
+        return c / 2.0 * (t * t * t * t * t + 2.0) + b;
     }
 
     return 0;
@@ -707,7 +734,9 @@ ICE_EASE_API double ICE_EASE_CALLCONV ice_ease_circ_in(ice_ease_type ease_type, 
 
     } else if (ease_type == ICE_EASE_TYPE_PENNER) {
         ICE_EASE_LOAD_FOUR_ARGS
-        return -c * (sqrt(1.0 - (t /= d) * t) - 1.0) + b;
+        t /= d;
+
+        return -c * (sqrt(1.0 - t * t) - 1.0) + b;
     }
 
     return 0;
@@ -722,7 +751,9 @@ ICE_EASE_API double ICE_EASE_CALLCONV ice_ease_circ_out(ice_ease_type ease_type,
 
     } else if (ease_type == ICE_EASE_TYPE_PENNER) {
         ICE_EASE_LOAD_FOUR_ARGS
-        return c * sqrt(1.0 - (t = t / d - 1.0) * t) + b;
+        t = t / d - 1.0;
+
+        return c * sqrt(1.0 - t * t) + b;
     }
 
     return 0;
@@ -733,13 +764,18 @@ ICE_EASE_API double ICE_EASE_CALLCONV ice_ease_circ_in_out(ice_ease_type ease_ty
 
     if (ease_type == ICE_EASE_TYPE_PROGRESS) {
         ICE_EASE_LOAD_ARG
+        
         if (x < 0.5) return (1.0 - sqrt(1.0 - pow(2.0 * x, 2))) / 2.0;
         return (sqrt(1.0 - pow(-2.0 * x + 2.0, 2)) + 1.0) / 2.0;
 
     } else if (ease_type == ICE_EASE_TYPE_PENNER) {
         ICE_EASE_LOAD_FOUR_ARGS
-        if ((t /= d / 2.0) < 1.0) return -c / 2.0 * (sqrt(1.0 - t * t) - 1.0) + b;
-        return c / 2.0 * (sqrt(1.0 - (t -= 2.0) * t) + 1.0) + b;
+        t /= d / 2.0;
+
+        if (t < 1.0) return -c / 2.0 * (sqrt(1.0 - t * t) - 1.0) + b;
+
+        t -= 2.0;
+        return c / 2.0 * (sqrt(1.0 - t * t) + 1.0) + b;
     }
 
     return 0;
@@ -759,14 +795,20 @@ ICE_EASE_API double ICE_EASE_CALLCONV ice_ease_elastic_in(ice_ease_type ease_typ
         return -pow(2.0, 10 * x - 10) * sin((x * 10.0 - 10.75) * c4);
 
     } else if (ease_type == ICE_EASE_TYPE_PENNER) {
+        double p, a, s, postFix;
         ICE_EASE_LOAD_FOUR_ARGS
-        double p = d * 0.3;
-        double a = c;
-        double s = p / 4.0;
-        double postFix = a * pow(2.0, 10 * (t -= 1));
+
+        p = d * 0.3;
+        a = c;
+        s = p / 4.0;
+        t -= 1.0;
+        postFix = a * pow(2.0, 10 * t);
 
         if (t == 0) return b;
-        else if ((t /= d) == 1) return b + c;
+        
+        t /= d;
+        if (t == 1.0) return b + c;
+        
         return -(postFix * sin((t * d - s) * (2.0 * ICE_EASE_PI) / p)) + b;
     }
 
@@ -795,11 +837,15 @@ ICE_EASE_API double ICE_EASE_CALLCONV ice_ease_elastic_out(ice_ease_type ease_ty
         else if (t == 1) return 1;
 
         if (t < 1.0) {
-            postFix = a * pow(2.0, 10 * (t -= 1));
+            t -= 1.0;
+            postFix = a * pow(2.0, 10 * t);
+
             return -0.5 * (postFix * sin((t * d - s) * (2.0 * ICE_EASE_PI) / p)) + b;
         }
 
-        postFix = a * pow(2.0, -10 * (t -= 1));
+        t -= 1.0;
+        postFix = a * pow(2.0, -10 * t);
+        
         return postFix * sin((t * d - s) * (2.0 * ICE_EASE_PI) / p) * 0.5 + c + b;
     }
 
@@ -830,11 +876,15 @@ ICE_EASE_API double ICE_EASE_CALLCONV ice_ease_elastic_in_out(ice_ease_type ease
         else if (t == 1) return 1;
 
         if (t < 1.0) {
-            postFix = a * pow(2.0, 10 * (t -= 1));
+            t -= 1.0;
+            postFix = a * pow(2.0, 10 * t);
+
             return -0.5 * (postFix * sin((t * d - s) * (2.0 * ICE_EASE_PI) / p)) + b;
         }
 
-        postFix = a * pow(2.0, -10 * (t -= 1));
+        t -= 1.0;
+        postFix = a * pow(2.0, -10 * t);
+
         return postFix * sin((t * d - s) * (2.0 * ICE_EASE_PI) / p) * 0.5 + c + b;
     }
 
@@ -855,8 +905,9 @@ ICE_EASE_API double ICE_EASE_CALLCONV ice_ease_back_in(ice_ease_type ease_type, 
     } else if (ease_type == ICE_EASE_TYPE_PENNER) {
         ICE_EASE_LOAD_FOUR_ARGS
         double s = 1.70158;
+        t /= d;
 
-        return c * (t /= d) * t * ((s + 1.0) * t - s) + b;
+        return c * t * t * ((s + 1.0) * t - s) + b;
     }
 
     return 0;
@@ -874,7 +925,9 @@ ICE_EASE_API double ICE_EASE_CALLCONV ice_ease_back_out(ice_ease_type ease_type,
     } else if (ease_type == ICE_EASE_TYPE_PENNER) {
         ICE_EASE_LOAD_FOUR_ARGS
         double s = 1.70158;
-        return c * ((t = t / d - 1.0) * t * ((s + 1.0) * t + s) + 1.0) + b;
+        t = t / d - 1.0;
+
+        return c * (t * t * ((s + 1.0) * t + s) + 1.0) + b;
     }
 
     return 0;
@@ -895,9 +948,16 @@ ICE_EASE_API double ICE_EASE_CALLCONV ice_ease_back_in_out(ice_ease_type ease_ty
         ICE_EASE_LOAD_FOUR_ARGS
         double s = 1.70158;
         double v = 1.525;
+        t /= d;
 
-        if ((t /= d / 2.0) < 1.0) return c / 2.0 * (t * t * (((s *= v) + 1.0) * t - s)) + b;
-        return c / 2.0 * ((t -= 2.0) * t * (((s *= v) + 1.0) * t + s) + 2.0) + b;
+        if (t < 1.0) {
+            s *= v;
+            return c / 2.0 * (t * t * ((s + 1.0) * t - s)) + b;
+        }
+
+        t -= 2.0;
+        s *= v;
+        return c / 2.0 * (t * t * ((s + 1.0) * t + s) + 2.0) + b;
     }
 
     return 0;
@@ -927,20 +987,38 @@ ICE_EASE_API double ICE_EASE_CALLCONV ice_ease_bounce_out(ice_ease_type ease_typ
         double n1 = 7.5625;
         double d1 = 2.75;
 
-        if (x < 1.0 / d1) return n1 * x * x;
-        else if (x < 2.0 / d1) return n1 * (x -= 1.5 / d1) * x + 0.75;
-        else if (x < 2.5 / d1) return n1 * (x -= 2.25 / d1) * x + 0.9375;
-        return n1 * (x -= 2.625 / d1) * x + 0.984375;
+        if (x < 1.0 / d1) {
+            return n1 * x * x;
+        } else if (x < 2.0 / d1) {
+            x -= 1.5 / d1;
+            return n1 * x * x + 0.75;
+        } else if (x < 2.5 / d1) {
+            x -= 2.25 / d1;
+            return n1 * x * x + 0.9375;
+        } else {
+            x -= 2.625 / d1;
+            return n1 * x * x + 0.984375;
+        }
 
     } else if (ease_type == ICE_EASE_TYPE_PENNER) {
         ICE_EASE_LOAD_FOUR_ARGS
         double n1 = 7.5625;
         double d1 = 2.75;
 
-        if ((t /= d) < (1.0 / d1)) return c * (n1 * t * t) + b;
-        else if (t < (2.0 / d1)) return c * (n1 * (t -= (1.5 / d1)) * t + 0.75) + b;
-        else if (t < (2.5 / d1)) return c * (n1 * (t -= (2.25 / d1)) * t + 0.9375) + b;
-        return c * (n1 * (t -= (2.625 / d1)) * t + 0.984375) + b;
+        t /= d;
+
+        if (t < (1.0 / d1)) {
+            return c * (n1 * t * t) + b;
+        } else if (t < (2.0 / d1)) {
+            t -= (1.5 / d1);
+            return c * (n1 * t * t + 0.75) + b;
+        } else if (t < (2.5 / d1)) {
+            t -= (2.25 / d1);
+            return c * (n1 * t * t + 0.9375) + b;
+        } else {
+            t -= (2.625 / d1);
+            return c * (n1 * t * t + 0.984375) + b;
+        }
     }
 
     return 0;

--- a/rebase/ice_ffi.h
+++ b/rebase/ice_ffi.h
@@ -1,4 +1,5 @@
 /*
+
 ice_ffi.h, Single-Header Cross-Platform C library for working with shared libs!
 
 
@@ -14,7 +15,7 @@ Check out "Linking Flags" to know which libs required to link for compilation de
 ================================== Usage Example ==================================
 
 // Define the implementation of the library and include it
-#define ICE_FFI_IMPL 1
+#define ICE_FFI_IMPL
 #include "ice_ffi.h"
 
 #include <stdio.h>
@@ -22,10 +23,15 @@ Check out "Linking Flags" to know which libs required to link for compilation de
 // Helper
 #define trace(fname, str) printf("[%s : line %d] %s() => %s\n", __FILE__, __LINE__, fname, str);
 
-int main(int argc, char **argv) {
+int main(void) {
+    // To store result of unloading the shared library/object
     ice_ffi_bool unload_res;
+
+    // Handle for shared library/object
     ice_ffi_handle lib;
-    unsigned (*F42)(void); // function from shared library/object
+
+    // function from shared library/object
+    unsigned (*F42)(void);
     
     // Define path of the shared library/object depending on platform
 #if defined(ICE_FFI_MICROSOFT)

--- a/rebase/ice_ram.h
+++ b/rebase/ice_ram.h
@@ -1,4 +1,5 @@
 /*
+
 ice_ram.h, Single-Header Cross-Platform C library to get RAM info!
 
 
@@ -22,14 +23,14 @@ Check out "Linking Flags" to know which libs required to link for compilation de
 // Helper
 #define trace(fname, str) printf("[%s : line %d] %s() => %s\n", __FILE__, __LINE__, fname, str);
 
-int main(int argc, char** argv) {
+int main(void) {
     // Struct that contains RAM information
     ice_ram_info ram;
 
     // Fetch RAM info
     ice_ram_bool res = ice_ram_get_info(&ram);
 
-    // If the function failed to fetch RAM info, Trace error then terminate the program
+    // If function failed to fetch RAM info, Trace error then terminate the program
     if (res == ICE_RAM_FALSE) {
         trace("ice_ram_get_info", "ERROR: failed to get RAM info!");
         return -1;
@@ -59,7 +60,7 @@ typedef enum ice_ram_bool {
 // RAM Information, Contains free and used and total RAM in bytes
 typedef struct ice_ram_info { ice_ram_bytes free, used, total; } ice_ram_info;
 
-// Retrives info about RAM (free, used, total) in bytes and stores info into ice_ram_info struct by pointing to, Returns ICE_RAM_TRUE on success or ICE_RAM_FALSE on failure
+// Retrieves info about RAM (free, used, total) in bytes and stores info into ice_ram_info struct by pointing to, Returns ICE_RAM_TRUE on success or ICE_RAM_FALSE on failure
 ice_ram_bool ice_ram_get_info(ice_ram_info *ram_info);
 
 
@@ -269,7 +270,7 @@ typedef struct ice_ram_info { ice_ram_bytes free, used, total; } ice_ram_info;
 
 /* ============================== Functions ============================== */
 
-/* Retrives info about RAM (free, used, total) in bytes and stores info into ice_ram_info struct by pointing to, Returns ICE_RAM_TRUE on success or ICE_RAM_FALSE on failure */
+/* Retrieves info about RAM (free, used, total) in bytes and stores info into ice_ram_info struct by pointing to, Returns ICE_RAM_TRUE on success or ICE_RAM_FALSE on failure */
 ICE_RAM_API ice_ram_bool ICE_RAM_CALLCONV ice_ram_get_info(ice_ram_info *ram_info);
 
 #if defined(__cplusplus)
@@ -308,7 +309,7 @@ ICE_RAM_API ice_ram_bool ICE_RAM_CALLCONV ice_ram_get_info(ice_ram_info *ram_inf
 #  include <sys/sysinfo.h>
 #endif
 
-/* Retrives info about RAM (free, used, total) in bytes and stores info into ice_ram_info struct by pointing to, Returns ICE_RAM_TRUE on success or ICE_RAM_FALSE on failure */
+/* Retrieves info about RAM (free, used, total) in bytes and stores info into ice_ram_info struct by pointing to, Returns ICE_RAM_TRUE on success or ICE_RAM_FALSE on failure */
 ICE_RAM_API ice_ram_bool ICE_RAM_CALLCONV ice_ram_get_info(ice_ram_info *ram_info) {
 #if defined(ICE_RAM_MICROSOFT)
     MEMORYSTATUSEX status;

--- a/rebase/ice_str.h
+++ b/rebase/ice_str.h
@@ -1,4 +1,5 @@
 /*
+
 ice_str.h, Single-Header Cross-Platform C library for working with Strings!
 
 
@@ -24,7 +25,7 @@ Check out "Linking Flags" to know which libs required to link for compilation de
 // Helper
 #define trace(fname, str) printf("[%s : line %d] %s() => %s\n", __FILE__, __LINE__, fname, str);
 
-int main(int argc, char **argv) {
+int main(void) {
     // Create a string repeated for multiple times
     char *haha = ice_str_dup("HA", 8); // HAHAHAHAHAHAHAHA
 
@@ -412,15 +413,13 @@ ICE_STR_API void ICE_STR_CALLCONV ice_str_arr_free(char **arr, unsigned long arr
 
 #if !defined(ICE_STR_CUSTOM_MEMORY_ALLOCATORS)
 #  include <stdlib.h>
-#  if defined(ICE_STR_MICROSOFT) && defined(_MSC_VER)
-#    pragma comment(lib, "msvcrt.lib")
-#  endif
 #endif
 
 /* Returns string length */
 ICE_STR_API unsigned long ICE_STR_CALLCONV ice_str_len(const char *str) {
     unsigned long res = 0;
-    while (str[res] != 0) res++;   
+    if (str == 0) return 0;
+    while (str[res] != 0) res++; 
     return res;
 }
 

--- a/rebase/ice_test.h
+++ b/rebase/ice_test.h
@@ -1,4 +1,5 @@
 /*
+
 ice_test.h, Single-Header Cross-Platform tiny C library for unit testing!
 
 
@@ -21,13 +22,13 @@ To use it #define ICE_TEST_IMPL then #include "ice_test.h" in your C/C++ code!
 #define trace(fname, str) printf("[%s : line %d] %s() => %s\n", __FILE__, __LINE__, fname, str);
 
 // Create a Test
-ICE_TEST_CREATE_EX(test1) {
+ICE_TEST_CREATE(test1) {
     ICE_TEST_ASSERT_TRUE(sizeof(void*) == 8);
 }
 
-int main(int argc, char **argv) {
+int main(void) {
     trace("main", "Testing if program is 64-bit...");
-    test1(argc, argv); // test!
+    test1(); // test!
     trace("main", "TEST SUCCESS!");
 
     return 0;
@@ -99,10 +100,6 @@ You can support or contribute to ice_libs project by possibly one of following t
 
 #include <assert.h>
 
-#if defined(_MSC_VER)
-#  pragma comment(lib, "msvcrt.lib")
-#endif
-
 /* Creates test with a name, This test can be called as name(); */
 #if defined(__cplusplus)
 #  define ICE_TEST_CREATE(name) extern "C" void name(void)
@@ -116,9 +113,9 @@ Creates test with a name but this one extended to allow argument passing...
 This test can be called as name(argc, argv);
 */
 #if defined(__cplusplus)
-#  define ICE_TEST_CREATE_EX(name) extern "C" void name(int argc, char** argv)
+#  define ICE_TEST_CREATE_EX(name) extern "C" void name(int argc, char **argv)
 #else
-#  define ICE_TEST_CREATE_EX(name) void name(int argc, char** argv)
+#  define ICE_TEST_CREATE_EX(name) void name(int argc, char **argv)
 #endif
 
 /*
@@ -130,6 +127,8 @@ Tests equality between 2 variables, For strings use ICE_TEST_ASSERT_STR_EQU inst
 #define ICE_TEST_ASSERT_STR_EQU(a, b) {         \
     unsigned long lenstr1, lenstr2, matches, i; \
     lenstr1 = lenstr2 = matches = 0;            \
+                                                \
+    assert((a != 0) && (b != 0));               \
                                                 \
     while (a[lenstr1] != 0) lenstr1++;          \
     while (b[lenstr2] != 0) lenstr2++;          \

--- a/rebase/ice_time.h
+++ b/rebase/ice_time.h
@@ -1,4 +1,5 @@
 /*
+
 ice_time.h, Single-Header Cross-Platform C library for working with Time!
 
 
@@ -22,7 +23,7 @@ Check out "Linking Flags" to know which libs required to link for compilation de
 // Helper
 #define trace(fname, str) printf("[%s : line %d] %s() => %s\n", __FILE__, __LINE__, fname, str);
 
-int main(int argc, char** argv) {
+int main(void) {
     // Struct that contains Time information
     ice_time_info current_time;
     
@@ -36,7 +37,7 @@ int main(int argc, char** argv) {
     }
 
     // Print current time!
-    printf("Current Time: %s\n", current_time.string);
+    printf("Current Time: %s\n", current_time.str);
 
     return 0;
 }
@@ -87,7 +88,7 @@ typedef enum ice_time_season {
 
 // Struct that contains patched current time info, Including ticks
 typedef struct ice_time_info {
-    const char* str;                // Time as string
+    const char *str;                // Time as string
     ice_time_ulong clock_ticks;     // Clock Ticks (Nanoseconds)
     ice_time_ulong uptime;          // Ticks since system started (Milliseconds)
     ice_time_ulong epoch;           // Unix timestamp
@@ -274,6 +275,13 @@ You can support or contribute to ice_libs project by possibly one of following t
 #if !defined(ICE_TIME_H)
 #define ICE_TIME_H 1
 
+/* Disable security warnings for MSVC compiler to not force usage of secure versions of various C functions (Which requires C11) */
+#if defined(_MSC_VER)
+#  define _CRT_SECURE_NO_DEPRECATE 1
+#  define _CRT_SECURE_NO_WARNINGS 1
+#  pragma warning(disable:4996)
+#endif
+
 /* Allow to use calling convention if desired... */
 #if defined(ICE_TIME_VECTORCALL)
 #  if defined(_MSC_VER)
@@ -438,7 +446,7 @@ typedef enum ice_time_season {
 
 /* Struct that contains patched current time info, Including ticks */
 typedef struct ice_time_info {
-    const char* str;                /* Time as string */
+    const char *str;                /* Time as string */
     ice_time_ulong clock_ticks;     /* Clock Ticks (Nanoseconds) */
     ice_time_ulong uptime;          /* Ticks since system started (Milliseconds) */
     ice_time_ulong epoch;           /* Unix timestamp */
@@ -563,7 +571,6 @@ typedef enum bool { false, true } bool;
 #    else
 #      pragma comment(lib, "kernel32.lib")
 #    endif
-#    pragma comment(lib, "msvcrt.lib")
 #  else
 #    include <sysinfoapi.h>
 #    include <synchapi.h>
@@ -592,13 +599,13 @@ typedef enum bool { false, true } bool;
 
 /* Returns difference between 2 clock ticks, Each one can be acquired via clock_ticks from struct ice_time_info */
 ICE_TIME_API ice_time_ulong ICE_TIME_CALLCONV ice_time_diff(ice_time_info t1, ice_time_info t2) {
-    long diff = t1.clock_ticks - t2.clock_ticks
+    long diff = t1.clock_ticks - t2.clock_ticks;
     return (ice_time_ulong)((diff < 0) ? 1 : diff);
 }
 
 /* Returns difference between clock tick of current time and clock time of specific time */
 ICE_TIME_API ice_time_ulong ICE_TIME_CALLCONV ice_time_since(ice_time_info t) {
-    ice_time_get_info current_time;
+    ice_time_info current_time;
     ice_time_error error = ice_time_get_info(&current_time);
     long diff;
 

--- a/samples/hello_ice_al.c
+++ b/samples/hello_ice_al.c
@@ -7,12 +7,12 @@
 /* Helper */
 #define trace(fname, str) printf("[%s : line %d] %s() => %s\n", __FILE__, __LINE__, fname, str);
 
-int main(int argc, char** argv) {
+int main(void) {
     ice_al_bool res;
 
     /* OpenAL device and OpenAL device name */
-    char* device_name;
-    ALCdevice* dev;
+    char *device_name;
+    ALCdevice *dev;
 
     /* Define the path of the OpenAL shared library/object depending on the platform (NOTE: You can also use OpenAL-soft) */
 #if defined(ICE_AL_MICROSOFT)
@@ -30,7 +30,7 @@ int main(int argc, char** argv) {
         return -1;
     }
     
-    /* Get the default OpenAL audio device and initialize */
+    /* Get the default OpenAL audio device and initialize it */
     device_name = alcGetString(NULL, ALC_DEFAULT_DEVICE_SPECIFIER);
     dev = alcOpenDevice(device_name);
     

--- a/samples/hello_ice_batt.c
+++ b/samples/hello_ice_batt.c
@@ -7,12 +7,12 @@
 /* Helper */
 #define trace(fname, str) printf("[%s : line %d] %s() => %s\n", __FILE__, __LINE__, fname, str);
 
-int main(int argc, char **argv) {
+int main(void) {
     /* Struct that contains information about the battery */
-    ice_batt_info info;
+    ice_batt_info batt;
 
     /* Fetch battery information and store the information in the struct */
-    ice_batt_error err = ice_batt_get_status(&info);
+    ice_batt_error err = ice_batt_get_info(&batt);
 
     /* If the function failed to fetch battery information, Trace error then terminate the program */
     if (err != ICE_BATT_ERROR_OK) {
@@ -20,11 +20,11 @@ int main(int argc, char **argv) {
         return -1;
     }
 
-    /* Print information we got */
+    /* Print the informations */
     printf("Device has battery: %s\nIs battery charging: %s\nBattery Level: %u\n",
-      (info.exists == ICE_BATT_TRUE) ? "YES" : "NO",
-      (info.charging == ICE_BATT_TRUE) ? "YES" : "NO",
-      info.level);
+      (batt.exists == ICE_BATT_TRUE) ? "YES" : "NO",
+      (batt.charging == ICE_BATT_TRUE) ? "YES" : "NO",
+      batt.level);
 
     return 0;
 }

--- a/samples/hello_ice_clip.c
+++ b/samples/hello_ice_clip.c
@@ -7,7 +7,7 @@
 /* Helper */
 #define trace(fname, str) printf("[%s : line %d] %s() => %s\n", __FILE__, __LINE__, fname, str);
 
-int main(int argc, char **argv) {
+int main(void) {
     /* To store result of called functions */
     ice_clip_bool res;
     
@@ -17,13 +17,12 @@ int main(int argc, char **argv) {
     /* Retrieve the clipboard text */
     const char *text = ice_clip_get();
 
-    /* If the function failed to retrieve Clipboard text, Trace error then terminate the program */
+    /* If the function failed to retrieve Clipboard text or Clipboard has no text then trace log a note, Else print the retrieved text... */
     if (text == NULL) {
-        trace("ice_clip_get", "ERROR: failed to retrieve Clipboard text!");
-        return -1;
+        trace("ice_clip_get", "LOG: failed to retrieve Clipboard text, Maybe the Clipboard does not contain text?");
+    } else {
+        printf("Text from the Clipboard: %s\n", text);
     }
-    
-    printf("Text from the Clipboard: %s\n", text);
 
     /* Clear the Clipboard */
     res = ice_clip_clear();
@@ -39,7 +38,7 @@ int main(int argc, char **argv) {
 
     /* If the function failed to copy text to the Clipboard, Trace error then terminate the program */
     if (res == ICE_CLIP_FALSE) {
-        printf("ERROR: Failed to copy text to Clipboard!\n");
+        trace("ice_clip_set", "ERROR: failed to copy text to Clipboard!");
         return -1;
     }
     

--- a/samples/hello_ice_cpu.c
+++ b/samples/hello_ice_cpu.c
@@ -7,12 +7,12 @@
 /* Helper */
 #define trace(fname, str) printf("[%s : line %d] %s() => %s\n", __FILE__, __LINE__, fname, str);
 
-int main(int argc, char **argv) {
+int main(void) {
     /* Struct that contains CPU information */
     ice_cpu_info cpu;
     
     /* Get CPU information */
-    ice_cpu_bool res = ice_cpu_get_status(&cpu);
+    ice_cpu_bool res = ice_cpu_get_info(&cpu);
     
     /* If the function failed to retrieve CPU information, Trace error then terminate the program */
     if (res == ICE_CPU_FALSE) {

--- a/samples/hello_ice_ease.c
+++ b/samples/hello_ice_ease.c
@@ -4,7 +4,7 @@
 
 #include <stdio.h>
 
-int main(int argc, char **argv) {
+int main(void) {
     double linear1, linear4;
 
     /* Use linear easing, With 1 argument (easings.net) */

--- a/samples/hello_ice_ffi.c
+++ b/samples/hello_ice_ffi.c
@@ -7,10 +7,15 @@
 /* Helper */
 #define trace(fname, str) printf("[%s : line %d] %s() => %s\n", __FILE__, __LINE__, fname, str);
 
-int main(int argc, char **argv) {
+int main(void) {
+    /* To store result of unloading the shared library/object */
     ice_ffi_bool unload_res;
+
+    /* Handle for shared library/object */
     ice_ffi_handle lib;
-    unsigned (*F42)(void); /* function from shared library/object */
+
+    /* function from shared library/object */
+    unsigned (*F42)(void);
     
     /* Define path of the shared library/object depending on platform */
 #if defined(ICE_FFI_MICROSOFT)

--- a/samples/hello_ice_ram.c
+++ b/samples/hello_ice_ram.c
@@ -7,7 +7,7 @@
 /* Helper */
 #define trace(fname, str) printf("[%s : line %d] %s() => %s\n", __FILE__, __LINE__, fname, str);
 
-int main(int argc, char** argv) {
+int main(void) {
     /* Struct that contains RAM information */
     ice_ram_info ram;
 

--- a/samples/hello_ice_str.c
+++ b/samples/hello_ice_str.c
@@ -7,7 +7,7 @@
 /* Helper */
 #define trace(fname, str) printf("[%s : line %d] %s() => %s\n", __FILE__, __LINE__, fname, str);
 
-int main(int argc, char **argv) {
+int main(void) {
     /* Create a string repeated for multiple times */
     char *haha = ice_str_dup("HA", 8); /* HAHAHAHAHAHAHAHA */
 

--- a/samples/hello_ice_test.c
+++ b/samples/hello_ice_test.c
@@ -8,13 +8,13 @@
 #define trace(fname, str) printf("[%s : line %d] %s() => %s\n", __FILE__, __LINE__, fname, str);
 
 /* Create a Test */
-ICE_TEST_CREATE_EX(test1) {
+ICE_TEST_CREATE(test1) {
     ICE_TEST_ASSERT_TRUE(sizeof(void*) == 8);
 }
 
-int main(int argc, char **argv) {
+int main(void) {
     trace("main", "Testing if program is 64-bit...");
-    test1(argc, argv); /* test! */
+    test1(); /* test! */
     trace("main", "TEST SUCCESS!");
 
     return 0;

--- a/samples/hello_ice_time.c
+++ b/samples/hello_ice_time.c
@@ -7,7 +7,7 @@
 /* Helper */
 #define trace(fname, str) printf("[%s : line %d] %s() => %s\n", __FILE__, __LINE__, fname, str);
 
-int main(int argc, char** argv) {
+int main(void) {
     /* Struct that contains Time information */
     ice_time_info current_time;
     
@@ -21,7 +21,7 @@ int main(int argc, char** argv) {
     }
 
     /* Print current time! */
-    printf("Current Time: %s\n", current_time.string);
+    printf("Current Time: %s\n", current_time.str);
 
     return 0;
 }


### PR DESCRIPTION
1. Removed linking `msvcrt.lib` to avoid some warnings when compiling with MSVC...
2. Fixed bindings for Nelua and LuaJIT and DragonRuby, Plus that examples where added for them...
3. Fixed `ice_al.h` on Microsoft platforms
4. Fixed undefined reference to `ice_batt_get_info` in `ice_batt.h` and now removed `using namespace` lines for C++ implementations (UWP, BlackBerry 10) and added correct headers...
5. In `ice_clip.h`, removed `using namespace` lines for C++ implementations (UWP, BlackBerry 10) and added correct headers, In addition to check if no data is in Clipboard on Windows (Example now does not error and terminate if the Clipboard has no text...)
6. Fixed `ice_cpu.h` implementation for Microsoft platforms and removed requirement for C string functions...
7. Typo fixes (Retrive -> Retrieve)
8. Updated usage examples inside the headers...
9. In `ice_str.h` now `ice_str_len` returns `NULL` (zero) safely as string length if `NULL` (or zero) passed as parameter...
10. Updated header implementations and samples to comply with `-Wextra` flag!
11. `ice_test.h` now asserts for being the strings are not `NULL` (or zero) when comparing using `ICE_TEST_ASSERT_STR_EQU` and also used `ICE_TEST_CREATE` instead of `ICE_TEST_CREATE_EX` in the usage example...
12. Added disable security `#pragmas` for `ice_time.h` on MSVC so it won't warn because we are not using the C11 secure versions of the standard C library functions...
13. The examples of the bindings with the samples by all were both tested with MSVC and GCC on Microsoft Windows and they should also work fine on any other C compiler or platform as it can use the suitable implementation...