### PR TITLE
General improvements for ice_ffi.h and ice_fs.h and ice_cpu.h

### DIFF
--- a/bindings/dragonruby/examples/hello_ice_time.rb
+++ b/bindings/dragonruby/examples/hello_ice_time.rb
@@ -9,7 +9,7 @@ def tick args
   
   # If the function failed to fetch time information, Trace error then terminate the program!
   if (res != ICE_TIME_ERROR_OK)
-    puts("ERROR: failed to get time info!")
+    puts("ERROR: failed to retrieve time info!")
     return -1
   end
   
@@ -19,6 +19,4 @@ def tick args
     y: 5.from_top,
     text: "Current Time: #{current_time.value.str.str}"
   }.to_label
-  
-  return 0
 end

--- a/bindings/luajit/examples/hello_ice_time.lua
+++ b/bindings/luajit/examples/hello_ice_time.lua
@@ -13,7 +13,7 @@ local function main()
   
   -- If the function failed to fetch time information, Trace error then terminate the program!
   if (res ~= ICE_TIME_ERROR_OK) then
-    print("ERROR: failed to get time info!")
+    print("ERROR: failed to retrieve time info!")
     return -1
   end
   

--- a/bindings/luajit/ice_cpu.lua
+++ b/bindings/luajit/ice_cpu.lua
@@ -19,7 +19,7 @@ typedef struct ice_cpu_info {
 
 /* ============================== Functions ============================== */
 
-/* Retreves info about CPU and stores info into ice_cpu_info struct by pointing to, Returns ICE_CPU_TRUE on success or ICE_CPU_FALSE on failure */
+/* Retrieves info about CPU and stores info into ice_cpu_info struct by pointing to, Returns ICE_CPU_TRUE on success or ICE_CPU_FALSE on failure */
 ice_cpu_bool ice_cpu_get_info(ice_cpu_info *cpu_info);
 ]])
 

--- a/bindings/nelua/examples/hello_ice_time.nelua
+++ b/bindings/nelua/examples/hello_ice_time.nelua
@@ -10,7 +10,7 @@ local function main(): cint
   
   -- If the function failed to fetch time information, Trace error then terminate the program!
   if (res ~= ICE_TIME_ERROR_OK) then
-    print("ERROR: failed to get time info!")
+    print("ERROR: failed to retrieve time info!")
     return -1
   end
   

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### March 9, 2022
+
+1. Security improvements have been done for `ice_al.h` and `ice_ffi.h`
+2. Extended string length for `ice_cpu_brand` (CPU Name) on Microsoft Platforms
+3. Fixed `ice_fs_type` function in `ice_fs.h` to be compatible with MSVC!
+4. Improved some samples...
+
 ### March 8, 2022
 
 1. ice_libs have passed 1 year on GitHub! (Happy Anniversary!)

--- a/rebase/ice_cpu.h
+++ b/rebase/ice_cpu.h
@@ -292,7 +292,7 @@ unsigned ice_cpu_brand[12];
 #  else
 #    include <sysinfoapi.h>
 #  endif
-char ice_cpu_brand[64];
+char ice_cpu_brand[128];
 #elif defined(ICE_CPU_BSD) || defined(ICE_CPU_APPLE) || defined(ICE_CPU_BLACKBERRY)
 #  include <stddef.h>
 #  if defined(__FreeBSD__) || defined(__DragonFly__) || defined(ICE_CPU_APPLE)

--- a/rebase/ice_ffi.h
+++ b/rebase/ice_ffi.h
@@ -315,17 +315,25 @@ ICE_FFI_API ice_ffi_handle ICE_FFI_CALLCONV ice_ffi_get(ice_ffi_handle lib, cons
 
 /* Loads shared library from path, Returns handle of loaded shared library on success or NULL on failure */
 ICE_FFI_API ice_ffi_handle ICE_FFI_CALLCONV ice_ffi_load(const char *path) {
-#if defined(ICE_FFI_MICROSOFT)
-    return LoadLibraryA(path);
-#elif defined(ICE_FFI_BEOS)
-    isize lib = load_add_on(path);
-
-    if (lib < 0) return 0;
-    
-    return (ice_ffi_handle) lib;
-#elif defined(ICE_FFI_UNIX)
-    return dlopen(path, RTLD_NOW | RTLD_GLOBAL);
+    ice_ffi_handle lib;
+#if defined(ICE_FFI_BEOS)
+    isize libsize;
 #endif
+
+    if (path == 0) return 0;
+
+#if defined(ICE_FFI_MICROSOFT)
+    lib = LoadLibraryA(path);
+#elif defined(ICE_FFI_BEOS)
+    libsize = load_add_on(path);
+    if (libsize < 0) return 0;
+    
+    lib = (ice_ffi_handle)(libsize);
+#elif defined(ICE_FFI_UNIX)
+    lib = dlopen(path, RTLD_NOW | RTLD_GLOBAL);
+#endif
+
+    return lib;
 }
 
 /* Unloads shared library loaded via ice_ffi_load, Returns ICE_FFI_TRUE on success or ICE_FFI_FALSE on failure */
@@ -347,16 +355,23 @@ ICE_FFI_API ice_ffi_bool ICE_FFI_CALLCONV ice_ffi_unload(ice_ffi_handle lib) {
 
 /* Loads symbol from shared library loaded via ice_ffi_load, Returns pointer to loaded symbol on success or NULL on failure */
 ICE_FFI_API ice_ffi_handle ICE_FFI_CALLCONV ice_ffi_get(ice_ffi_handle lib, const char *symbol) {
-#if defined(ICE_FFI_MICROSOFT)
-    return GetProcAddress(lib, symbol);
-#elif defined(ICE_FFI_BEOS)
     ice_ffi_handle sym;
-    int res = get_image_symbol((isize) lib, symbol, B_SYMBOL_TYPE_ANY, &sym);
-
-    return (res == 0) ? sym : 0;
-#elif defined(ICE_FFI_UNIX)
-    return dlsym(lib, symbol);
+#if defined(ICE_FFI_BEOS)
+    int call_res;
 #endif
+
+    if (symbol == 0) return 0;
+
+#if defined(ICE_FFI_MICROSOFT)
+    sym = GetProcAddress(lib, symbol);
+#elif defined(ICE_FFI_BEOS)
+    call_res = get_image_symbol((isize) lib, symbol, B_SYMBOL_TYPE_ANY, &sym);
+    if (call_res != 0) return 0;
+#elif defined(ICE_FS_UNIX)
+    sym = dlsym(lib, symbol);
+#endif
+
+    return sym;
 }
 
 #endif  /* ICE_FFI_IMPL */

--- a/rebase/ice_fs.h
+++ b/rebase/ice_fs.h
@@ -1600,7 +1600,7 @@ ICE_FS_API ice_fs_object_type ICE_FS_CALLCONV ice_fs_type(const char *path) {
     res = stat(path, &info);
     if (res == -1) return ICE_FS_OBJECT_TYPE_NONE;
 
-    return ((int)(S_ISDIR(info.st_mode)) == 1) ? ICE_FS_OBJECT_TYPE_DIR : ICE_FS_OBJECT_TYPE_FILE;
+    return ((int)((info.st_mode & S_IFMT) == S_IFDIR)) ? ICE_FS_OBJECT_TYPE_DIR : ICE_FS_OBJECT_TYPE_FILE;
 }
 
 /* Reads content of file and returns the content on allocation success or NULL on failure, file_size is pointer to unsigned long integer that will store number of chars (bytes) the file has */

--- a/samples/hello_ice_al.c
+++ b/samples/hello_ice_al.c
@@ -31,7 +31,7 @@ int main(void) {
     }
     
     /* Get the default OpenAL audio device and initialize it */
-    device_name = alcGetString(NULL, ALC_DEFAULT_DEVICE_SPECIFIER);
+    device_name = alcGetString(0, ALC_DEFAULT_DEVICE_SPECIFIER);
     dev = alcOpenDevice(device_name);
     
     /* If the function failed to initialize the default OpenAL device, Trace error then terminate the program */

--- a/samples/hello_ice_clip.c
+++ b/samples/hello_ice_clip.c
@@ -18,7 +18,7 @@ int main(void) {
     const char *text = ice_clip_get();
 
     /* If the function failed to retrieve Clipboard text or Clipboard has no text then trace log a note, Else print the retrieved text... */
-    if (text == NULL) {
+    if (text == 0) {
         trace("ice_clip_get", "LOG: failed to retrieve Clipboard text, Maybe the Clipboard does not contain text?");
     } else {
         printf("Text from the Clipboard: %s\n", text);

--- a/samples/hello_ice_ffi.c
+++ b/samples/hello_ice_ffi.c
@@ -28,7 +28,7 @@ int main(void) {
     lib = ice_ffi_load(path);
     
     /* If the function failed to load the shared library/object, Trace error then terminate the program */
-    if (lib == NULL) {
+    if (lib == 0) {
         trace("ice_ffi_load", "ERROR: failed to load shared library/object!");
         return -1;
     }
@@ -37,7 +37,7 @@ int main(void) {
     *(unsigned**)(&F42) = ice_ffi_get(lib, "F42");
     
     /* If the function failed to get symbol from shared library/object, Trace error then terminate the program */
-    if (F42 == NULL) {
+    if (F42 == 0) {
         trace("ice_ffi_get", "ERROR: failed to get symbol from shared library/object!");
         return -1;
     }
@@ -46,7 +46,7 @@ int main(void) {
     printf("F42 call result: %u\n", F42());
     
     /* When done, Unload symbols and the shared library/object */
-    F42 = NULL;
+    F42 = 0;
     unload_res = ice_ffi_unload(lib);
     
     /* If the function failed to unload shared library/object, Trace error then terminate the program */

--- a/samples/hello_ice_time.c
+++ b/samples/hello_ice_time.c
@@ -16,7 +16,7 @@ int main(void) {
 
     /* If the function failed to fetch time information, Trace error then terminate the program! */
     if (res != ICE_TIME_ERROR_OK) {
-        trace("ice_time_get_info", "ERROR: failed to get time info!");
+        trace("ice_time_get_info", "ERROR: failed to retrieve time info!");
         return -1;
     }
 


### PR DESCRIPTION
1. Security improvements have been done for `ice_al.h` and `ice_ffi.h`
2. Extended string length for `ice_cpu_brand` (CPU Name) in `ice_cpu.h` on Microsoft Platforms
3. Fixed `ice_fs_type` function in `ice_fs.h` to be compatible with MSVC!
4. Improved some samples...